### PR TITLE
feat: stream-once, transform-many image processing pipeline

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,12 @@ import createClient from "./utils/createClient.js";
 import fetchBucketObjects from "./utils/fetchBucketObjects.js";
 import fetchObject from "./utils/fetchObject.js";
 import groupObjects from "./utils/groupObjects.js";
+import groupDifferences from "./utils/groupDifferences.js";
 import transformAndUpload from "./utils/transformAndUpload.js";
 
 import { createLogger, getLogger } from "./utils/logger.js";
+
+import transformationTasks from "./tasks/index.js";
 
 const { differenceBy } = lodash;
 
@@ -23,6 +26,11 @@ const {
 } = process.env;
 
 const logger = createLogger({ level: LOG_LEVEL });
+
+/**
+ * @typedef {import('sharp').Sharp} Sharp
+ * @typedef {function(Sharp): Readable} TransformerFunction
+ */
 
 async function handler(done) {
   try {
@@ -43,22 +51,52 @@ async function handler(done) {
     });
     logger.trace({ items }, "fetchBucketObjects:result");
 
-    const { minified, images } = groupObjects(items);
-    logger.trace({ minified, images }, "groupObjects:result");
+    const { minified, small, medium, large, images } = groupObjects(items);
+    logger.trace(
+      { minified, small, medium, large, images },
+      "groupObjects:result",
+    );
 
     const unminified = differenceBy(images, minified, "Key");
-    logger.debug({ unminified }, "differenceBy:result");
+    const unsmall = differenceBy(images, small, "Key");
+    const unmedium = differenceBy(images, medium, "Key");
+    const unlarge = differenceBy(images, large, "Key");
 
-    for (const image of unminified) {
-      const imageObject = await fetchObject(image.Key, {
+    logger.debug(
+      { unminified, unsmall, unmedium, unlarge },
+      "differenceBy:result",
+    );
+
+    const groupedDifferences = groupDifferences(images, {
+      unminified,
+      unsmall,
+      unmedium,
+      unlarge,
+    });
+
+    logger.debug({ groupedDifferences }, "groupDifferences:result");
+
+    for (const [imageKey, tasks] of Object.entries(groupedDifferences)) {
+      if (tasks.length === 0) continue;
+
+      const imageObject = await fetchObject(imageKey, {
         client: s3Client,
         bucket: DO_SPACE_BUCKET,
       });
+
+      logger.info({ imageKey, tasks }, "processing image");
+
+      const transformers = Object.fromEntries(
+        tasks.map((slug) => [slug, transformationTasks[slug]]),
+      );
+
       await transformAndUpload(imageObject, {
         client: s3Client,
         bucket: DO_SPACE_BUCKET,
+        transformers,
       });
     }
+
     logger.info("processing completed");
     done({
       listedImages: items.length,
@@ -78,18 +116,24 @@ const MINUTELY_CRON = "*/1 * * * *";
 const HOURLY_CRON = "0 */1 * * *";
 const EVERY_4TH_HOUR_CRON = "0 */4 */1 * *";
 
+const onComplete = (data) => {
+  const logger = getLogger("onComplete");
+  logger.info({ data }, "processed information");
+};
+
+const errorHandler = (err) => {
+  const logger = getLogger("errorHandler");
+  logger.error({ err }, "error occurred");
+};
+
+// handler(onComplete);
+
 const job = CronJob.from({
   name: "minify-images",
   cronTime: HOURLY_CRON,
   onTick: handler,
-  onComplete: (data) => {
-    const logger = getLogger("onComplete");
-    logger.info({ data }, "processed information");
-  },
-  errorHandler: (err) => {
-    const logger = getLogger("errorHandler");
-    logger.error({ err }, "error occurred");
-  },
+  onComplete,
+  errorHandler,
   start: false,
   waitForCompletion: true,
   timeZone: "UTC",

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert";
+import lodash from "lodash";
+
+const { differenceBy } = lodash;
+
+import groupObjects from "./utils/groupObjects.js";
+import groupDifferences from "./utils/groupDifferences.js";
+
+const mockItems = [
+  { Key: "first.jpg" },
+  { Key: "first-sm.jpg" },
+  { Key: "first-lg.jpg" },
+  { Key: "second.jpg" },
+  { Key: "second-min.jpg" },
+  { Key: "second-sm.jpg" },
+  { Key: "third.jpg" },
+  { Key: "third-md.jpg" },
+  { Key: "forth.jpg" },
+  { Key: "forth-lg.jpg" },
+  { Key: "fifth.jpg" },
+];
+
+test("index", async (t) => {
+  await t.test("grouped differences", async () => {
+    const { minified, small, medium, large, images } = groupObjects(mockItems);
+
+    const unminified = differenceBy(images, minified, "Key");
+    const unsmall = differenceBy(images, small, "Key");
+    const unmedium = differenceBy(images, medium, "Key");
+    const unlarge = differenceBy(images, large, "Key");
+
+    assert.deepEqual(
+      unminified,
+      [
+        { Key: "first.jpg" },
+        { Key: "third.jpg" },
+        { Key: "forth.jpg" },
+        { Key: "fifth.jpg" },
+      ],
+      "should have unminified images",
+    );
+    assert.deepEqual(
+      unsmall,
+      [{ Key: "third.jpg" }, { Key: "forth.jpg" }, { Key: "fifth.jpg" }],
+      "should have unsmall images",
+    );
+    assert.deepEqual(
+      unmedium,
+      [
+        { Key: "first.jpg" },
+        { Key: "second.jpg" },
+        { Key: "forth.jpg" },
+        { Key: "fifth.jpg" },
+      ],
+      "should have unmedium images",
+    );
+    assert.deepEqual(
+      unlarge,
+      [{ Key: "second.jpg" }, { Key: "third.jpg" }, { Key: "fifth.jpg" }],
+      "should have unlarge images",
+    );
+    assert.deepEqual(
+      images,
+      [
+        { Key: "first.jpg" },
+        { Key: "second.jpg" },
+        { Key: "third.jpg" },
+        { Key: "forth.jpg" },
+        { Key: "fifth.jpg" },
+      ],
+      "should have all images grouped",
+    );
+  });
+
+  await t.test("images grouped by difference", async () => {
+    const { minified, small, medium, large, images } = groupObjects(mockItems);
+
+    const unminified = differenceBy(images, minified, "Key");
+    const unsmall = differenceBy(images, small, "Key");
+    const unmedium = differenceBy(images, medium, "Key");
+    const unlarge = differenceBy(images, large, "Key");
+
+    const groupedDifferences = groupDifferences(images, {
+      unminified,
+      unsmall,
+      unmedium,
+      unlarge,
+    });
+
+    assert.deepEqual(groupedDifferences, {
+      "first.jpg": ["-min", "-md"],
+      "second.jpg": ["-md", "-lg"],
+      "third.jpg": ["-min", "-sm", "-lg"],
+      "forth.jpg": ["-min", "-sm", "-md"],
+      "fifth.jpg": ["-min", "-sm", "-md", "-lg"],
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "sharp": "0.34.2"
       },
       "devDependencies": {
+        "mock-import": "4.2.1",
         "pino-pretty": "13.0.0"
       },
       "engines": {
@@ -901,6 +902,109 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
+      "integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.1",
+        "@csstools/css-tokenizer": "^3.0.1"
+      }
+    },
+    "node_modules/@dual-bundle/import-meta-resolve": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
@@ -909,6 +1013,279 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
+      "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.15.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -1305,6 +1682,2281 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
+      "integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@keyv/serialize/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@putout/babel": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/babel/-/babel-3.2.0.tgz",
+      "integrity": "sha512-05ZVVKdT4cRgAKitceZb33h3RPEukXcrLba60rn4j36HA788YAgYWeieXs3j+uju4k/bMxswTVVL7mOTLwT9pQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/cli-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/cli-cache/-/cli-cache-5.0.1.tgz",
+      "integrity": "sha512-HPou7SWvXWtJbBwxqyBCZBjp0uc18wyqa+RdQwUkucxMVlSAZ/1p6oNGDZ/cYKogo8Vx/+E2OLhKpYvzcOqOwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "file-entry-cache": "^10.0.2",
+        "find-cache-dir": "^5.0.0",
+        "imurmurhash": "^0.1.4",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "try-catch": "^3.0.1",
+        "try-to-catch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/cli-choose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/cli-choose/-/cli-choose-2.0.0.tgz",
+      "integrity": "sha512-q9gj1cX/fKuXJjtEgQ+CsHhbiA2CGJ5TTIVZwdv32w5WKAiYfo6cIxCliZpa8ZX978X8uDDgWJ1DPgLHXc/tRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "enquirer": "^2.4.1",
+        "try-to-catch": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/cli-choose-formatter": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/cli-choose-formatter/-/cli-choose-formatter-4.0.0.tgz",
+      "integrity": "sha512-GEvHT5ifDKq5QP3Z96Xz4qs8CtmgxJQzGFUX79luF2o0+KLHyP9vUIK10bRorPoLHvHNSe3AHUIynsEg5TMn/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/cli-choose": "^2.0.0",
+        "find-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/cli-filesystem": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/cli-filesystem/-/cli-filesystem-2.1.0.tgz",
+      "integrity": "sha512-dPi4i0G8n9hrkXolF850y3Qpd/rt1GgifYEelrkjXPZmmPASIpYyj0Hkep47oqf6xbpWiuyl38fWyUsSSvWLBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/cli-keypress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/cli-keypress/-/cli-keypress-2.0.0.tgz",
+      "integrity": "sha512-EXJv2HaXM+5scjoxE6Tf+o4+pxwL1tYJZJBDMygrF7cocjirGcU05GgNr9WHOaUPaVOpVjVU98ugYD7XJLmMkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^4.0.0",
+        "fullstore": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@putout/cli-match": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/cli-match/-/cli-match-2.2.0.tgz",
+      "integrity": "sha512-g6IqlSN34AhQ6Gk/hrJR3Mm/qJCJD1PJjRzwxxa+gDCbusKWMOfX70EymUBBV5SCPMnLWQByzXHwOPo88/uPDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "try-catch": "^3.0.0",
+        "try-to-catch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@putout/cli-process-file": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@putout/cli-process-file/-/cli-process-file-2.4.0.tgz",
+      "integrity": "sha512-57xSnyqB9EBnMYjRn6Gh+BaEzAURHn96bQJNC5Rf0WdgO3Woa9Ya0SmlwMEhPNKYmy/JCQbOTofaD3WGeO/I7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/eslint": "^4.0.0",
+        "@putout/formatter-eslint": "^2.0.2",
+        "deepmerge": "^4.3.1",
+        "once": "^1.4.0",
+        "samadhi": "^2.14.1",
+        "try-catch": "^3.0.0",
+        "try-to-catch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/cli-ruler": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/cli-ruler/-/cli-ruler-3.1.0.tgz",
+      "integrity": "sha512-40LVNOrotdBWjBmi8Ee0kTtQDpje4fau8BvNdV6hsWk2gIbg6G/SrrhA/VrADVwCW1nGBkpe19f6803Zy1kUDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "try-to-catch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@putout/cli-staged": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/cli-staged/-/cli-staged-1.1.0.tgz",
+      "integrity": "sha512-JJAxlNvFqOv1GhourIZfhSe+RPtWMuJxMjX9HdaEi5UmbQiOHziRZ5s0nOTriCbYtez5DpVs0mv5j6zvd3rHCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/git-status-porcelain": "^3.0.0",
+        "fullstore": "^3.0.0",
+        "once": "^1.4.0",
+        "try-to-catch": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@putout/cli-validate-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/cli-validate-args/-/cli-validate-args-2.0.0.tgz",
+      "integrity": "sha512-/tl1XiBog6XMb1T9kalFerYU86sYsl6EtrlvGI5RVtlHOQdEEJAIPRxmX4vnKG3uoY5aVEkJOWzbPM5tsncmFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fastest-levenshtein": "^1.0.12",
+        "just-kebab-case": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/compare": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@putout/compare/-/compare-16.0.3.tgz",
+      "integrity": "sha512-McjCUi7o2ycp8cN8RJxyrv0pdW/uFac7OXMpvX/1eThB0Ak7zBW48lD729EoQECQvJD/dCswmcmabz16W3J9Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/engine-parser": "^12.0.0",
+        "@putout/operate": "^13.0.0",
+        "debug": "^4.1.1",
+        "jessy": "^4.1.0",
+        "nessy": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/engine-loader": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/@putout/engine-loader/-/engine-loader-15.4.1.tgz",
+      "integrity": "sha512-ygjM9N7LziS00OGZL/iU/QjmlGKT7Af8VDFB39XDaxgLIgEjOkLByhrzdpYD2bPCvcVsekFsV7qdAgaeMfzbig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-match-patch": "^1.0.4",
+        "nano-memoize": "^3.0.11",
+        "once": "^1.4.0",
+        "try-catch": "^3.0.0",
+        "try-to-catch": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": "*"
+      }
+    },
+    "node_modules/@putout/engine-parser": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@putout/engine-parser/-/engine-parser-12.6.0.tgz",
+      "integrity": "sha512-BhRnvkzqdqw799x7RMfftgaB6SiDkAh3sjkZSLZGZLtFtI4j9ygHSaGrLOw+bl5f1EAM9RH/raFatrRLf3R2qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/printer": "^13.0.0",
+        "align-spaces": "^2.0.0",
+        "estree-to-babel": "^10.0.0",
+        "nano-memoize": "^3.0.11",
+        "once": "^1.4.0",
+        "try-catch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/engine-processor": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/engine-processor/-/engine-processor-13.0.0.tgz",
+      "integrity": "sha512-1HHesRQvDed7T4t4Hy7OPcWHKhwmI8ggcpFTYn3IxTYgn7kgDiRV8g9mC+85a0YNmBqRAqbgKwWzMeNen5y2+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/engine-loader": "^15.0.1",
+        "once": "^1.4.0",
+        "picomatch": "^4.0.2",
+        "try-to-catch": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": "*"
+      }
+    },
+    "node_modules/@putout/engine-reporter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/engine-reporter/-/engine-reporter-3.0.0.tgz",
+      "integrity": "sha512-T9CptPBujx6hEJFvRikvs1dW4i4puhbe7FpjkgJhGnz85tIdD45tstqumBOQcUF7adbLzoCkOdTbSHBV3sJJLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/cli-choose-formatter": "^4.0.0",
+        "@putout/cli-keypress": "^2.0.0",
+        "@putout/engine-loader": "^15.0.1",
+        "fullstore": "^3.0.0",
+        "try-catch": "^3.0.1",
+        "try-to-catch": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": "*"
+      }
+    },
+    "node_modules/@putout/engine-runner": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/@putout/engine-runner/-/engine-runner-23.6.0.tgz",
+      "integrity": "sha512-rU9LwSLxZvK0IrW4LoO+umQwHRvmZBY7ea7eN9b7RAnbkGCCKUYcuojAR7Nb6wdbr8KgDS2XrbeW6cuciluyEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/compare": "^16.0.0",
+        "@putout/engine-parser": "^12.0.0",
+        "@putout/operate": "^13.0.0",
+        "@putout/operator-declare": "^11.0.3",
+        "@putout/operator-filesystem": "^6.0.2",
+        "@putout/operator-json": "^2.0.0",
+        "@putout/plugin-filesystem": "^8.0.1",
+        "debug": "^4.1.1",
+        "fullstore": "^3.0.0",
+        "jessy": "^4.0.0",
+        "nessy": "^5.2.0",
+        "once": "^1.4.0",
+        "try-catch": "^3.0.0",
+        "wraptile": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": "*"
+      }
+    },
+    "node_modules/@putout/eslint": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/eslint/-/eslint-4.1.0.tgz",
+      "integrity": "sha512-kwo2TJUzC4Rj65ZSkUFb/7WYfsNlHdMqp9jqnwH3y+056QNeifyt9PHCIZPCrOJ1lT7bxhCInUjPrpgilr50+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0",
+        "try-to-catch": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
+    "node_modules/@putout/formatter-codeframe": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-codeframe/-/formatter-codeframe-8.0.0.tgz",
+      "integrity": "sha512-AT7qWeLYi7S6a9s79mHnJcNfq+K2c9KMYHboZeT55zSM3LXLshbY4CmUFdL8w2Zmz5z/17nHFNXhFdqO4EpunA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/formatter-json": "^2.0.0",
+        "chalk": "^5.3.0",
+        "table": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/formatter-dump": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-dump/-/formatter-dump-5.0.0.tgz",
+      "integrity": "sha512-txlOnphn2pfvbkyYmKbw+zAc+T/Q01958zy0e5jR+AQcWCGyCgjBAeVMh+pUBZ7+Zyl/CAnou0zG87t7hTYA9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/formatter-json": "^2.0.0",
+        "chalk": "^5.3.0",
+        "table": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/formatter-eslint": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-eslint/-/formatter-eslint-2.0.2.tgz",
+      "integrity": "sha512-xFYRI1f4zzrvKOpgQXXtldw73FcdunfphcphFxUhQLtCKcPK50K7k9RB5iaWlZo8hD2oitY7vxzE4jNBbfV4yQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/formatter-json": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "putout": ">=22.5"
+      }
+    },
+    "node_modules/@putout/formatter-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-frame/-/formatter-frame-7.0.0.tgz",
+      "integrity": "sha512-9sgBlotE4rWYUpvMpp5+hBqcCWzQLBKu2nzJaawBBxurOde0sOSAqWkSDxRIjahtXlL4nc7LrYPvKyH5p7NSDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/formatter-codeframe": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/formatter-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-json/-/formatter-json-2.0.0.tgz",
+      "integrity": "sha512-g+mpOU/s+ciQDkukKwTg5WGmQKFlfca/cpdeYQmuVFsbabkcFAVA5QWMQiGvmXx4Cg9PuJXvhYKfGB0zCcGCiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "putout": ">=22.5"
+      }
+    },
+    "node_modules/@putout/formatter-json-lines": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-json-lines/-/formatter-json-lines-3.0.0.tgz",
+      "integrity": "sha512-Np+Zpm/FqQpjiIatTg6k8+KUq4JfnfXYcoUJ3s4wwNq+OQqc1T/b2fPkctddwTei/fsh7s7wXgcAUxu8B+J3Yw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=25"
+      }
+    },
+    "node_modules/@putout/formatter-memory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-memory/-/formatter-memory-4.0.1.tgz",
+      "integrity": "sha512-S3ctALHkGQRbr6zJ4kPoo7ZNBnfxXZi66XTMc/Md8k5enS0H1ATNKcwDNdA06CB0QrC5P866VX6wPRB1PHr4Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/formatter-dump": "^5.0.0",
+        "chalk": "^5.3.0",
+        "cli-progress": "^3.8.2",
+        "format-io": "^2.0.0",
+        "montag": "^1.1.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/formatter-progress": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-progress/-/formatter-progress-5.0.0.tgz",
+      "integrity": "sha512-sOmQ1xAW/3GgYKrz8NpPI341B3L1vG9RLSzbdgQqLQQLkPWIqvewnqzpukgFMKG2XVhT04/VZyzoMH+7rM2y+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/formatter-dump": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/formatter-progress-bar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-progress-bar/-/formatter-progress-bar-4.0.1.tgz",
+      "integrity": "sha512-sqnCwTPliKb4ln8Ss8h/KVx539u4qDc7cqCjSzQda2zQO+rfBAMhOS4Km4MUnbglOVw89JM5fbQ25x2tRjFpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/formatter-dump": "^5.0.0",
+        "chalk": "^5.3.0",
+        "cli-progress": "^3.8.2",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/formatter-stream": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-stream/-/formatter-stream-5.0.0.tgz",
+      "integrity": "sha512-4uS8YHf9R+T1Qo7mQqDOA/BgedS7KcA0cMGNvafzm06L9QET1RcnbcHyJPAMhjpc23r8n2QJ9q/TGpE1185I/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "table": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/formatter-time": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-time/-/formatter-time-3.0.1.tgz",
+      "integrity": "sha512-qxxgiinxbf9BCdz7kSKiKZ/lJtfQtU1IpOB3iHCDSVfBn7gAJ2Tk5m6Dwc5wC6Cqe+1aO1pjR/JTp9skCXKf9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/formatter-dump": "^5.0.0",
+        "chalk": "^5.3.0",
+        "cli-progress": "^3.8.2",
+        "format-io": "^2.0.0",
+        "montag": "^1.1.0",
+        "once": "^1.4.0",
+        "timer-node": "^5.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/git-status-porcelain": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/git-status-porcelain/-/git-status-porcelain-3.0.0.tgz",
+      "integrity": "sha512-TJxXfrpZGzSf7pQ96MMBpPICtM5G9r7MAWKpH3GJi3deGII3ILLibA47P2qMeUbCmXml5wG6DTQS7OZFOrTIUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@putout/operate": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@putout/operate/-/operate-13.5.0.tgz",
+      "integrity": "sha512-chPBFIsUsJpQDsI3pGbIIqsCH63ntq2WwOO2xetxz4G+5zAw58X3k4J6Zq9jNPT6Cz+RFQpwqi0vE7fJ3vEkkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/operator-add-args": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/operator-add-args/-/operator-add-args-10.0.1.tgz",
+      "integrity": "sha512-L7/5stBe5qIu93/smyb+xG6pSiB8rQzNJim0knEml0h5fbV7oBDv0CfLGUAl3HVLmxZpU0ke0megpmTcLV5Asw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/compare": "^16.0.0",
+        "@putout/engine-parser": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/operator-declare": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/operator-declare/-/operator-declare-11.1.0.tgz",
+      "integrity": "sha512-QYp7s0pnBObp+eFq2n7OoSUZ6qUUXzvd5jq88EIn0j3NDpkVnN/+tKsH14dYm/9D+4ZmDRG4HErK3eN21/oHaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/compare": "^16.0.0",
+        "@putout/engine-parser": "^12.0.0",
+        "@putout/operate": "^13.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/operator-filesystem": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@putout/operator-filesystem/-/operator-filesystem-6.4.1.tgz",
+      "integrity": "sha512-ryTcocfjh0x+x00cZ8b/QtRTmae0Ynj6itsRKaetIP5o9V+esXjjdniz/R5MkvNKMbkcnoAvn/BW/JZMlWMdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/operate": "^13.0.0",
+        "fullstore": "^3.0.0",
+        "try-catch": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/operator-ignore": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/operator-ignore/-/operator-ignore-2.0.0.tgz",
+      "integrity": "sha512-PcYwlaHyLWzjEJG3NQ17REhpbfYBjWZ3Z/TxI418mp59xrMs2LRlHuxqPSof1B85iQ9Ck8rTfRk0xEcTOcCw0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/operate": "^13.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/operator-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/operator-json/-/operator-json-2.2.0.tgz",
+      "integrity": "sha512-yPY+Cc9FzUXfYzlhR+qhyu/KdD3qd5NwQnjGZfgJxYAPvZAFSgBYEQ8LRXZ1/8vLAGDc3Lytu3zL5TU7xJS9bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remove-blank-lines": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/operator-keyword": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/operator-keyword/-/operator-keyword-2.2.0.tgz",
+      "integrity": "sha512-5cF7s7df+ajHkMEz2r7xIgwdRoFRt6su/Vm9umE7LfRWcq85aQcb4j4mZIkhbWX2+MLV/NDW1w+MW+514T8rhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/operator-match-files": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/operator-match-files/-/operator-match-files-6.0.1.tgz",
+      "integrity": "sha512-X0KqMVEvvP6/q9TUu1akGLyaU2rani/9Og5lDNdyqtgqHlNQKwwLZaeQ/C3QOc454KfbWHqUvvqlEHFD3EyqWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/engine-parser": "^12.0.0",
+        "@putout/operator-filesystem": "^6.0.2",
+        "@putout/operator-json": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/operator-parens": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/operator-parens/-/operator-parens-1.2.0.tgz",
+      "integrity": "sha512-pl6n9drxYXbyyqwBfZWPrL5nwXYsX+gGqnwpbzUeBE6n8RLB3MFB/n1CmFiIE0Ae9sBxFQQtU0FS6NW16/k2VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/operator-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/operator-regexp/-/operator-regexp-1.0.0.tgz",
+      "integrity": "sha512-ts9QqsrpPCcXH9uao8ZjgxjvhdhaT7rZYy0JDKkfv0tptC55LEN8b9/0G4ZfVTm39C+7V+WFrDR0bDccyPd0yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "^0.1.24"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "putout": ">=20"
+      }
+    },
+    "node_modules/@putout/operator-rename-files": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/operator-rename-files/-/operator-rename-files-2.0.1.tgz",
+      "integrity": "sha512-Ydsjb5yLqdxbmqSXBnv+N8qu1uCi8bcN+RAx61ii9fh16EwT/nuDKnT54T+3dcax7GK7Dz6zI/BS6z9TajZNpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/operator-filesystem": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-apply-arrow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-arrow/-/plugin-apply-arrow-2.0.0.tgz",
+      "integrity": "sha512-PEJeoYrbhsrdoqlGtdK2K2nuICabKutdUppb/70lo7OvvA9WzR1rHTQ0aN4FEtY03lpk4Tr8QHhPpS8a0PL3Mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-apply-at": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-at/-/plugin-apply-at-2.0.0.tgz",
+      "integrity": "sha512-wIQz42w+d+CugaLdNbksGAdL1CxfpHFb7Yr2bn2bqi+jI6Dr6AlrbvpN9irE1dcAY+5hbVmSfe8euix0trkR3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=32"
+      }
+    },
+    "node_modules/@putout/plugin-apply-destructuring": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-destructuring/-/plugin-apply-destructuring-8.0.1.tgz",
+      "integrity": "sha512-yxiEyL0sXLQpiNscr65LeIsLQzaIaCUZ95DNnjXBWFGujJFH+VZUmXY9LgPPU9lppZzrQkiFjmlplaEW7SFSFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-apply-dot-notation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-dot-notation/-/plugin-apply-dot-notation-2.0.0.tgz",
+      "integrity": "sha512-Bo7MqwyFzH5FisSGsOP0rWjcebziKoaJkQhQXug27EmdCkEuuhacHgjv4k4j3E9/VuZMcJdsSM92i+vX2kR3Ag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/plugin-apply-flat-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-flat-map/-/plugin-apply-flat-map-2.0.0.tgz",
+      "integrity": "sha512-TH+Al9LJqKZeyrh1Yg2/lwmIXdpZx6yINTf6vtCa1cdd5ebCAe6hGbU7VttZMcQzFCWZwqJX2BCPKtSr+4RAwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=28"
+      }
+    },
+    "node_modules/@putout/plugin-apply-overrides": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-overrides/-/plugin-apply-overrides-2.1.0.tgz",
+      "integrity": "sha512-uu/G5rJufqWj+qhaDBL0+NFejVrwb/JVdB//8jW74I3sLcYDKiTDU5z2+hNWMCE8ORae+gr6PCWJfiEC9v2ROw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-apply-shorthand-properties": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-shorthand-properties/-/plugin-apply-shorthand-properties-6.1.0.tgz",
+      "integrity": "sha512-zM/5nRFqkVssDrK7fsPQLngkK+QO8vvn1hlPA4bg8Nyjt1arAaLUZEv8vjrVWtofzAsTjyE74fW4cbnG+lBm5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-apply-starts-with": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-starts-with/-/plugin-apply-starts-with-1.1.0.tgz",
+      "integrity": "sha512-DZrZyMslqpBiRtONNZXUXR1eeJwz57Arb+b4luWkgyIpaYJdMOU0umfzvEfbnMY7TT+LWKxKSpZx4AV3HIDZPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=30"
+      }
+    },
+    "node_modules/@putout/plugin-apply-template-literals": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-template-literals/-/plugin-apply-template-literals-4.2.0.tgz",
+      "integrity": "sha512-wqyMnU+4V6DBf4dSwFq4X1BHNhTlons61S+u3JNjj8A8uHvjz4MC2zeet5FxFZytq9DkomN6vt1jwuuS3V6E8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-browserlist": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-browserlist/-/plugin-browserlist-2.0.0.tgz",
+      "integrity": "sha512-1wo8BQZuO7lrlQCR9HTG6OeUrHrC46iPlc5vPVewvHVK/ghfxprAHq/SpuUbwGU71rFPFTS/SoOfJ/OxCa5fxA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=33"
+      }
+    },
+    "node_modules/@putout/plugin-conditions": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-conditions/-/plugin-conditions-7.3.1.tgz",
+      "integrity": "sha512-I0fzotT9uILMkRojNQ84w6fVaVzIk2fOCTpRUmI7GZmZseP74YOUj63ctiiJxe8VU/CmEtVeMR/xwls2MhdW7w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-convert-apply-to-spread": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-apply-to-spread/-/plugin-convert-apply-to-spread-4.0.0.tgz",
+      "integrity": "sha512-AHjlnPoEuYza/m5fOU/wRdSpsTggT2bI1Vo4g5A7NL/WXkA4IhRbbtw+uI4il8EOpzcZUmMOve/+O0kRfc6VXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-convert-arguments-to-rest": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-arguments-to-rest/-/plugin-convert-arguments-to-rest-3.1.0.tgz",
+      "integrity": "sha512-DkjkCIc2ecbqvc8yhKWLDx2bGlNq5RMRlTfYd++nXi2iRnf5SyqcBfmr3/u/7BGoaoTN4QpDwPx9hyZXnK/PLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-convert-array-copy-to-slice": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-array-copy-to-slice/-/plugin-convert-array-copy-to-slice-3.0.0.tgz",
+      "integrity": "sha512-rmUhado8IydOc+amBzBLiQ7j39TadIrDwyaEZmAcLG1LrQNQ8LGssvnKqE0EqRBy3t/D3y3r4PKKR2sklqz7+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-convert-assignment-to-arrow-function": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-assignment-to-arrow-function/-/plugin-convert-assignment-to-arrow-function-1.2.2.tgz",
+      "integrity": "sha512-c0wH8tkAlogllIIYZmxEdMRwS27c4bLLQKNgYKrCgZs4RS39dutgK41aCZQWsCKfDl9ruGF2DaEJ034BSManZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "putout": ">=15"
+      }
+    },
+    "node_modules/@putout/plugin-convert-assignment-to-comparison": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-assignment-to-comparison/-/plugin-convert-assignment-to-comparison-2.0.1.tgz",
+      "integrity": "sha512-GUsl7Jcppc4olsoRChx+jayW2YW1y2FH3tL3yKBgQsHeVxOcHW+f+uzFyVdTuTSQ2FokDMe5h5alLCYVFLimVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-convert-assignment-to-declaration": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-assignment-to-declaration/-/plugin-convert-assignment-to-declaration-2.0.1.tgz",
+      "integrity": "sha512-PAprnY5/lerzqaDBk96PXu2ePzLMJf4V2+y+F+KUVAaT3QVAZK3sIBCsAWaag7ZAvQ5/TbpWOTwTUBzLZf5pSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-convert-concat-to-flat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-concat-to-flat/-/plugin-convert-concat-to-flat-1.0.0.tgz",
+      "integrity": "sha512-5vpw+xZ+00xQW6Ql9Ku6MrARV/EPq1KrTAHYYaBTLyMZcpNaM3L+LYJ08/Cc1/mm64ufBa3LTaFJtr9PrzmuHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "putout": ">=16"
+      }
+    },
+    "node_modules/@putout/plugin-convert-const-to-let": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-const-to-let/-/plugin-convert-const-to-let-4.2.0.tgz",
+      "integrity": "sha512-m2+l2VyAHzeKPm5nWgW0KqEekaqWpH/EJbxWvtz58wXpnC1RR6YpW+JGQCp0cRJTIfO7xO3lqM4KVL34RZNDrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-convert-expression-to-params": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-expression-to-params/-/plugin-convert-expression-to-params-1.0.3.tgz",
+      "integrity": "sha512-KT+CeeCEcIGinkWgA7viYip7RCvra9au9b49yEdZ/W9VP/J0C0ikr+p5S0UNe/6Vq5Ri29CU8d0eHD1ASg6Bwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-convert-index-of-to-includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-index-of-to-includes/-/plugin-convert-index-of-to-includes-2.0.1.tgz",
+      "integrity": "sha512-l8OA1+5hzviySeGTYsKZFBLALIye0at/ewRnvXQI5bH3s2De7d8OdMn5x7wdHwTph1NyrCwo4sLHlQX6E/fG7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-convert-object-assign-to-merge-spread": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-object-assign-to-merge-spread/-/plugin-convert-object-assign-to-merge-spread-6.0.0.tgz",
+      "integrity": "sha512-EdEgVRhIXZq6bV0WVcUwz0Zm72eEeWrWcccuKYnmUgJ20rL0LpUmxdVuTvDEzDsX4WjQXku32ACfAn/nUEfwiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=25"
+      }
+    },
+    "node_modules/@putout/plugin-convert-object-entries-to-array-entries": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-object-entries-to-array-entries/-/plugin-convert-object-entries-to-array-entries-3.0.2.tgz",
+      "integrity": "sha512-S3U6C1vAUS272TGYrAeWz2UJA2jPn8H7qBJ2IzgI1kAycO1IXnOyFn3iuBLC9pY2ireehVC1TKVrZMkC2b6NZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=31"
+      }
+    },
+    "node_modules/@putout/plugin-convert-quotes-to-backticks": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-quotes-to-backticks/-/plugin-convert-quotes-to-backticks-4.0.3.tgz",
+      "integrity": "sha512-T2//CIlKw99tVwoGhn86jYujElnm7iAoCEZ/TZrCPpt8nAcki1I8Yr3UwzKnVJW2epjtXU5MaPh2M8Vd/v/x9g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-convert-template-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-template-to-string/-/plugin-convert-template-to-string-2.0.0.tgz",
+      "integrity": "sha512-+qlmSL5Clg51KFI+o9oQfeQxKkKsx9c2JuPjLsuejCn8rp9wFLh9f/7SzoL7PNaBwrG0atcQUlqN0a3W/aXU3A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/plugin-convert-to-arrow-function": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-to-arrow-function/-/plugin-convert-to-arrow-function-4.0.0.tgz",
+      "integrity": "sha512-oE+jmjjrSxD9BtLEiHnqW0UA7wXPzNrt46iNbrGRT6EkoKcJogp1BedP6bMlvdJUsHZu/Lx1Ib1unPQ7dWk+Tg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-coverage": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-coverage/-/plugin-coverage-1.0.0.tgz",
+      "integrity": "sha512-YX44zFIuSgWWxAVc0/uqKbqJDUBthya1QC/ov6H0GRX1vKVkqhCwcUzJ3i9DDyGLrzfhOGfzFagtZys9wRPx2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/plugin-declare": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-declare/-/plugin-declare-5.0.0.tgz",
+      "integrity": "sha512-fLP8WL3TQ1d/0bowfIUgY8/x9ViO4QY/6iYbsz2j/WaWFhEqjR/cdoi3vHSgIoVA5qo5TFJmF+Fyssigv5FIcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-declare-before-reference": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-declare-before-reference/-/plugin-declare-before-reference-6.2.0.tgz",
+      "integrity": "sha512-P2YPYyLoq4vagbwdktNxQTTtigekBn9xwuZeEELpkuXs7PwCRIkGPsi8bEdxWZz1ItohOB/br1d1FIcwaNDa2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-eslint": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-eslint/-/plugin-eslint-12.4.0.tgz",
+      "integrity": "sha512-OIJ4TknUwfrNj76htntJGWK6RRi2fmbv2KQ4VS9OhsgUBTTKwaFcaLPoc6UQImiWuOhhhF5cFsIo+dDN0d6YLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-esm": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-esm/-/plugin-esm-2.3.0.tgz",
+      "integrity": "sha512-q3Qj6eQ/yYSmAKD6VJBW/vK3/jd2OBZdq+kJiGlb1ZHIrRNWWdU5C4/ZbWSY7uiQXhaYKsTF1uIg9+riVvqtkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-import-specifiers": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-extract-keywords-from-variables": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-extract-keywords-from-variables/-/plugin-extract-keywords-from-variables-2.2.0.tgz",
+      "integrity": "sha512-zzmF305c8jgQDcTBwdXEzEyv8r8P5Fs12YLEznPrcl4wXsfVffm5O8otQZvCx1taHhtVCmQFfDGXN34IGiCrNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-extract-object-properties": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-extract-object-properties/-/plugin-extract-object-properties-9.0.0.tgz",
+      "integrity": "sha512-26RafMuaxdjJS9Y9TJC+uyxYU9VyprdQtpcL5xHbUA66DurUbY+7Gg3yxGfs2dNd+czd3gRB2TQ/3x9MSuFmjw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-extract-sequence-expressions": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-extract-sequence-expressions/-/plugin-extract-sequence-expressions-3.5.0.tgz",
+      "integrity": "sha512-ywDbX0CpgweJrT7xiakwb2IEjzjQL4tdMXrBuW6OjVzOs6mNcuaFEHGMXnzFuNNCYOWpoUwr2oHdim++8QVuwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=25"
+      }
+    },
+    "node_modules/@putout/plugin-filesystem": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-filesystem/-/plugin-filesystem-8.3.0.tgz",
+      "integrity": "sha512-VQpuEa8efO2AJQcAY6kS9pbWOUwkR7w6+0x/7JSepoPS7WFko7zeS5oi5tQ9ht/Sd4N57QHS0Jznn3Xvf+S+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/operate": "^13.0.0",
+        "@putout/operator-filesystem": "^6.0.2",
+        "@putout/operator-json": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-for-of": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-for-of/-/plugin-for-of-8.1.0.tgz",
+      "integrity": "sha512-zNr9xA2lyjccArtBFCOqxZaER6qZRcQJHkrx7Tmh4G8WJzve3XNE8fMlk5WTrgPRKL/cosV7pnrsdlFkxqjrlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-generators": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-generators/-/plugin-generators-1.0.0.tgz",
+      "integrity": "sha512-5rETQ4xphQ3pH20AtoW9hn/jmTsVMS/8Sw0Uz0sa2cmSBRx/Nl9777ltrRx+dFZ1jj0f59uCT9mnHIe31Th44w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fullstore": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/plugin-github": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-github/-/plugin-github-14.0.0.tgz",
+      "integrity": "sha512-+WDImw1s6KH83rcOePKL9lNhinoEJQnDPRGuLz+Wsc9E7NmLiCXoxBsl+YI3qqv+FYE7VNaFyaYEH3BS3CXRPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-gitignore": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-gitignore/-/plugin-gitignore-6.0.0.tgz",
+      "integrity": "sha512-uiAfT/shB+gsAAdy1I2UBFt005W//wgadEnXIRvwSBiA77u/VkxMJdPO7st2J6bBLTn/4tIh1WAeSuAEGC63QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/plugin-labels": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-labels/-/plugin-labels-1.0.0.tgz",
+      "integrity": "sha512-kQ0R2cfmv+IiWUTZnCLZxmmxss5HiUPk6WA5lJTjbKMgRMUt6w3aZeeD23nbqqL8BXpT/OkQ242tmY7EXRCM7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fullstore": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-logical-expressions": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-logical-expressions/-/plugin-logical-expressions-7.0.1.tgz",
+      "integrity": "sha512-N8iMUrD5EWhCiLGhBzrSnjQ3kLmKmhA4skjpz2ew+rHwYAz1YkAgy3ahg0XmWMs3fvsMR5bxayd8J+kVagTe1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-madrun": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-madrun/-/plugin-madrun-20.0.1.tgz",
+      "integrity": "sha512-2rH1vrvoiwfnKOzlEeT5PZPfOKWj/AJAmpe1+r0B3tqaOG/lUpRVHEp/uoCfUu6uJ5hWdsxdFZUsicWO/Yq2pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-math": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-math/-/plugin-math-3.4.0.tgz",
+      "integrity": "sha512-3/y22K37Nu5dfyBVd31p+9pYo66k8cXxIcKqh8Ive4D0wY8oIN08ovtGJCOJZzxgSFpjMK7cayBbPUB9XqSQJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-maybe": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-maybe/-/plugin-maybe-3.0.0.tgz",
+      "integrity": "sha512-9dQxRA46OxAxOifWGdYUF7Oru7pbHKRb4LMZbA42LUbTsa6Pthc5TisTaHAY6eX3OiIN097HomhWjyryeM4oyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-merge-destructuring-properties": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-merge-destructuring-properties/-/plugin-merge-destructuring-properties-10.0.0.tgz",
+      "integrity": "sha512-PgM2vFAE9LvXneL0mBrcfDJRsm4xq8Aj5QmC5kTFBxQ1yqXjjEB/co2UwoMJcqLyUbX78X+814mj1To+RDHKHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-merge-duplicate-functions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-merge-duplicate-functions/-/plugin-merge-duplicate-functions-2.0.0.tgz",
+      "integrity": "sha512-FhhyFksBVRR7RfOUWrFgH+j7NvbRkWrKs1mKDWR7TzPbAs2STWmR45j6UeYoItbujWBo0Udk7UxhdUwR6ymRdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=32"
+      }
+    },
+    "node_modules/@putout/plugin-montag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-montag/-/plugin-montag-3.0.0.tgz",
+      "integrity": "sha512-uztGdO8qN0ZWgcUuZLSevIwkxZ2xFI9l2N9VJui6U6/VlV3vBsj/rud9DG6PkD6vlYHCLCtcHyTvEzx/PIr3Pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-new": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-new/-/plugin-new-3.0.1.tgz",
+      "integrity": "sha512-DXlkD30gfjd28Ef0Gs/sPjJTFFIaxXUygK7t6xb1xUeIqWlrqev9lPEkjHiV0dD+iPNEtswaiwCd2javrym+TQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=33"
+      }
+    },
+    "node_modules/@putout/plugin-nodejs": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-nodejs/-/plugin-nodejs-14.1.0.tgz",
+      "integrity": "sha512-mdwL/kmxQ7mod8bBZLRnAjPSjQ1vsGIyDhHErOhW6uQn0qCLHpUIcMDS4CIVu+4szFkEjc7hmMCLL4vUVz2dwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "just-camel-case": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=18.6"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-npmignore": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-npmignore/-/plugin-npmignore-5.0.0.tgz",
+      "integrity": "sha512-k43d+6dCW9tiueQjyq1+h6GAcXuB79VJzBXE8sME5IPk31HVUlYfhWKHB5IaG1DT9F4+BVuyvZbIXYXdeLK+hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/plugin-optional-chaining": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-optional-chaining/-/plugin-optional-chaining-1.0.4.tgz",
+      "integrity": "sha512-Kv8gMUGKnN0HIwM6rH6sMpkV3fLQtB5GmBXxsb7ArELvAyd7tw3veG9YXLRnBahXvaIaFcdkn/sIel8vDMkVTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-package-json": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-package-json/-/plugin-package-json-9.1.1.tgz",
+      "integrity": "sha512-Xy3nQwTOVqG3Y+ehY2NpWuXqHkyTzkiJalmKJwMHVs+CgyS1vPl7mBpjkd7cvaa6sewmCjPJOtVhdSNRNuWI/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-parens": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-parens/-/plugin-parens-2.1.0.tgz",
+      "integrity": "sha512-gtrARPLvJA7J5JbmrSWi2wYrTSBrmqJgJSXAF6SKCaa0cE1ptTLakc0Fmqo2xxhtnkvE2ze50fqoUVPsVIKSdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-promises": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-promises/-/plugin-promises-16.0.0.tgz",
+      "integrity": "sha512-lGkmSs1WJHRLXZ+pjN/KOdwQh2BSNbvdPa0LJYyXauGApamy36Q9FtyN9PBqKCQI/ZcI3n7iGh54/sMWBn9mog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fullstore": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-putout": {
+      "version": "23.16.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-putout/-/plugin-putout-23.16.0.tgz",
+      "integrity": "sha512-49EBG96mUj3qeyzR2JZfUS9kGn3SGqAQFgocRb4ynI8ddhYBfxwJI1j8dee++HGxsnupxWq6CO1JzKBIF7z2Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fullstore": "^3.0.0",
+        "just-camel-case": "^6.2.0",
+        "parse-import-specifiers": "^1.0.2",
+        "try-catch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-putout-config": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-putout-config/-/plugin-putout-config-8.1.0.tgz",
+      "integrity": "sha512-VphY+omZsG9r9TX5ywc7rzDsmpB0US/h6fTQNINq6QypUm4c+ecDiXgyszFKJ6o0qRZvhzfaVOhRRNfpbs2xFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-regexp": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-regexp/-/plugin-regexp-10.0.0.tgz",
+      "integrity": "sha512-oISppaFndgoDeO4YrEAeRdb4UfCkjYAr0gN1WjmfefrGI8EIsgYGiJZqaBXnTW3psLhg4RF9+ltKn0EKGisSug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "^0.1.21",
+        "try-catch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-console": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-console/-/plugin-remove-console-6.0.0.tgz",
+      "integrity": "sha512-MpnIc0JmB7z3VMcqJnBdzkg2NTOorLb6WKpt3PWlSh8HZ1lqz78CRW7styHYTtSg5fcp/zkPUk4nkbxMPuoOiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-remove-constant-conditions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-constant-conditions/-/plugin-remove-constant-conditions-4.0.2.tgz",
+      "integrity": "sha512-UN+SlFVkSFbKjA9aw9WT32SaKnfeBo+TX0fqDu/dAyoe7gp8GAXRnDr/Yw02kRkDHmAYEcoKd1EGpRhhWHX1Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=25"
+      }
+    },
+    "node_modules/@putout/plugin-remove-debugger": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-debugger/-/plugin-remove-debugger-7.0.0.tgz",
+      "integrity": "sha512-dFjtdP1r6RITDZMb6JG4ddQo0K5p2pX3mL09VByCWy0LXDHZIGkbEqn5Q4C1ydkRy7iH8+qug3wRWnsI8Z7txA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/plugin-remove-duplicate-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-duplicate-case/-/plugin-remove-duplicate-case-3.0.0.tgz",
+      "integrity": "sha512-NLj45ob0RDk///SNTo3h+rJGbK3l22RkkRih2e7xg7ky6fKMtBCuMk0IYI8/mNNDR0Xm6UKwvBC9nFzqp9stTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=30"
+      }
+    },
+    "node_modules/@putout/plugin-remove-duplicate-keys": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-duplicate-keys/-/plugin-remove-duplicate-keys-7.0.0.tgz",
+      "integrity": "sha512-aQUMSofnmCOkmNiX75SbTI975dh2ue21+IYbGj0AhA/R33ay5L1AehLc7Z09C8xb/uK/+lRMW/+7TyZZp3NTLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fullstore": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-empty": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-empty/-/plugin-remove-empty-14.0.0.tgz",
+      "integrity": "sha512-QvWon0eDNIyg+Ttz4sk0qUiOZsRqMDSpVEV1ATFz11pk11odE0mu1lkZyHjx6rpzBG0cEI1FuaE5hCXCYKMTwQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-iife": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-iife/-/plugin-remove-iife-4.1.0.tgz",
+      "integrity": "sha512-sprRQalN9BRJ28iz2LPhnz4bM6qjwlnRZoHZY7+a4Grqp/mFeKcnvfWsL/EUaeykHCnSk/tC6umLlCbme/I8OA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-remove-nested-blocks": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-nested-blocks/-/plugin-remove-nested-blocks-8.1.0.tgz",
+      "integrity": "sha512-nt+3QSS8S9vbFvfjHNJmzLL2dJtOPF46qIaAfG9VCoV3qSJuMPb7VIn9hksPozQzCBwzkkwZmuSe1GgyTEcxMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-unreachable-code": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unreachable-code/-/plugin-remove-unreachable-code-2.2.0.tgz",
+      "integrity": "sha512-9MBdfs/wPKUXZYDXKZPa7imc96p42GfY48kL31aVVs5yl+3Mdndul+MoLGoFZYzuP/xQ33RNRjM5BaIoF0jPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-remove-unreferenced-variables": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unreferenced-variables/-/plugin-remove-unreferenced-variables-5.0.0.tgz",
+      "integrity": "sha512-jwo50Ll1y5fptK7M41NYQc20gKAu4Hk05vLxxRRVtPq7K+TFeEhlsY6McG0clhsE69DY/53OgC89HhS8FonsFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-unused-expressions": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unused-expressions/-/plugin-remove-unused-expressions-11.0.0.tgz",
+      "integrity": "sha512-4rIkgMo3P7fWcQov+lVBDyCdYAEu5C8Jy4cHBrwOjnWsVhEQrw8uUhgMR1xRgoyzUizsmET/WvT70KgYPKpl5w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-unused-for-of-variables": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unused-for-of-variables/-/plugin-remove-unused-for-of-variables-3.0.1.tgz",
+      "integrity": "sha512-nFsBnRYdvSEBvOmKOzqMaWSlimX6K6jLl3HRX0KlfyJI/EOQYqjqPBvTRq3XS0resZw4LZ2cSPduL/dYuR1juw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=25"
+      }
+    },
+    "node_modules/@putout/plugin-remove-unused-labels": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unused-labels/-/plugin-remove-unused-labels-1.0.2.tgz",
+      "integrity": "sha512-cDyMWovbcPclTOJh9ZM0BTw4KyQndrzKwtOKNG1dhfStLWZrux95VgO6hFwdYM8yPGj3RsA3mJLn3W26+DwJJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-remove-unused-private-fields": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unused-private-fields/-/plugin-remove-unused-private-fields-3.1.0.tgz",
+      "integrity": "sha512-7fba2S1k/sX77ssYLG0rlUgTA2vIEjAwMkcyWe4gTWVXdD9bunNvzlX8pd7OitbgYFNSiD9Zw2AnzP+rcthUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-unused-variables": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unused-variables/-/plugin-remove-unused-variables-12.1.0.tgz",
+      "integrity": "sha512-GCIcCk+iR+yEdyOq5YcE47Gi528e8QIyQije/e39zoCbCYdVXC92ErWEdDm5aag0TuHPJ/Z/Rm5TQ224A9MZ5w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-arguments": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-arguments/-/plugin-remove-useless-arguments-11.0.0.tgz",
+      "integrity": "sha512-eyJqXFgZQpDlDrlMys5163wyEhqD10rhXd+D0qg4ElORDPvbZTIkeSEZSAzUF95Bc4i+dTtoOKDcHLkV5A7/6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-array/-/plugin-remove-useless-array-1.1.0.tgz",
+      "integrity": "sha512-xWwGpvhtCiglwYjUZXOAple09QRnNZkCR8waoKxIlr8STSKB+6DGrdDCDw7A36fUNrTX96D4svGn1fHNAR6XIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=35"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-array-constructor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-array-constructor/-/plugin-remove-useless-array-constructor-2.0.0.tgz",
+      "integrity": "sha512-R3GAHGeDoh916SSEFrPaiEu9BylOrIP07+Xh+v+hzZuw/tINiA94sdWZ4BPhOmIX3qbWe6LqqVQ4j8VikaaF9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "putout": ">=30"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-array-entries": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-array-entries/-/plugin-remove-useless-array-entries-1.0.0.tgz",
+      "integrity": "sha512-ArLWIUXH1ajRPRe/6Pv4MhW3HAFoet4dy1fMlYVa+2i2ydjVYsKnwdJU70cI9B2Mo25JQXUY5yskkSaRQx339g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "putout": ">=23"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-assign/-/plugin-remove-useless-assign-1.1.0.tgz",
+      "integrity": "sha512-lfTkCAVYKacsEuZRjVogH29FUH9xE3+7+15VEVzPPMiBdsACOJ9561yldXeqy6u/+9rwmmkYr8W1Bt7VyQEyvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=26"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-constructor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-constructor/-/plugin-remove-useless-constructor-2.0.0.tgz",
+      "integrity": "sha512-nssmppJkz2d0xTzmPKIMtFgAyicRff4q9VuwLRahnUZ8NPN6kVdMoXb73VGy7ZYd5nMlGg/rxaF0hgZPqQ2R8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-continue": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-continue/-/plugin-remove-useless-continue-2.0.0.tgz",
+      "integrity": "sha512-OxG5fr4uIGSmITzX4pkYPBYnn1NaGu9ZSBCzcrNrG5/7mGNIO9YnC9yyVRjTXELdxJXL5sjxzoBCSsS33PMwFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=28"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-delete": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-delete/-/plugin-remove-useless-delete-1.0.4.tgz",
+      "integrity": "sha512-Gsq1UW8cOTwldLQHU6xEZHVNQQCEyM0diSyvufVxqMvAAVx5fvtbK/Kzosk56OB0lXn3SjiPg/EtGiZt0vwaLg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-escape": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-escape/-/plugin-remove-useless-escape-7.0.0.tgz",
+      "integrity": "sha512-9V0utpql3pFZ9zFBSH8sR3I5MoE87q4NfJOoKSeBok9bUx4vn+4I2v6k1QhS1FC00zM8xLG3cQF+ns/Pw+Dqzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-functions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-functions/-/plugin-remove-useless-functions-4.0.0.tgz",
+      "integrity": "sha512-ZntUotrsyAh9TQOiYAhYW70nF7clYZCWOuqfpbdzzT9fv2LJggMDOpScaLoy36pws9PI4NZOcio2PqlQlstdPA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-map/-/plugin-remove-useless-map-1.1.0.tgz",
+      "integrity": "sha512-/5VQNb1YkcTZ16FqFrSfoILgGqsMJ6zIaKP1LlhZa3Xt1svLoN2Y2NIve9mSn7NgxFWnR1eUZPaeXl+FT+ltog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "putout": ">=18"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-operand": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-operand/-/plugin-remove-useless-operand-2.1.0.tgz",
+      "integrity": "sha512-Et+8ZHBRD1zTHjYu71lC22rRuwayI4r4yQw+kibvwIEgVvLBbJu8DhlTKKjWkH04BQWEtigSwd/kKQSL0bVo+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=25"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-push": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-push/-/plugin-remove-useless-push-1.0.3.tgz",
+      "integrity": "sha512-G0e0QY6p9bd1HU5h8NoV/fMGI6+O2AWGXxQzkgPHiwtpklk4nIXkGtCLpZqNFpoa/bT9MvXUL9cgWfL5tIaoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-replace": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-replace/-/plugin-remove-useless-replace-1.0.4.tgz",
+      "integrity": "sha512-w4TdcqM/9UOjv3YtyRldV49P95o32MIYyVe4aSxyAD4m29f/tnzD11RsCDC20mHZzSK3BIVpB72guK2U0ylqGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=26"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-spread": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-spread/-/plugin-remove-useless-spread-12.0.0.tgz",
+      "integrity": "sha512-64B4AsXWcqCZJF/aG8M0Fd4WMMO9Hpm71OALaHhJmp+t5PXK2gihMAaSP61l4+GUWXYzXGu0ARkXPSVfuRC31g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-template-expressions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-template-expressions/-/plugin-remove-useless-template-expressions-2.0.0.tgz",
+      "integrity": "sha512-1Dcnjc4h2Nd6eSvdTEhgtSbqvCMVxv6Mbvhj2yXjzNyP0vMi/CIUta23gM7Ie5Kzpkf/g9xhUUVqYVwYKjIkKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-remove-useless-variables": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-variables/-/plugin-remove-useless-variables-13.0.2.tgz",
+      "integrity": "sha512-Xd1NBXFGEuq04uhRpDRJl5t0ZfHraR8by+o8oArPJq3teoqIEW5KRbMQ7F9GCyrEMqlKGpODOZoZzFQ7+bwP/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-return": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-return/-/plugin-return-1.1.2.tgz",
+      "integrity": "sha512-QbCay24r8PNv9j8EjjZ/wdHVhLvuyqVdAbFM04iYOrC85XUJvY4MgCnVuj5N4vFhBEH0GWwhvNaaBZgc4hRBKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-reuse-duplicate-init": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-reuse-duplicate-init/-/plugin-reuse-duplicate-init-7.0.0.tgz",
+      "integrity": "sha512-Z7/uA4ZcfAJDZT7Sp5NBDCj6BR4gZ3sZbUx5JfQzwrKY0LlbdbWwd6iN69ElX36xCUNeYLKdQJqv4/vjPw6V3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-simplify-assignment": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-simplify-assignment/-/plugin-simplify-assignment-3.1.1.tgz",
+      "integrity": "sha512-ZomBcCeDAFzCDkOhPLgSRfQhuRZed0lxs2oYt3AT91Ld2e+LnadSBe7cjTZpr7Lyi5yCggT+e1ZHCs7j1yeXzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-simplify-ternary": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-simplify-ternary/-/plugin-simplify-ternary-7.0.0.tgz",
+      "integrity": "sha512-sSXTE4mOgkzVsVRv73DAEUBLRTouwW2ts0tDxOFqY0ipqjI9fNhHTl+ifF9b9DvNyi66MiAmhV4sVOuPFq4xUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=34"
+      }
+    },
+    "node_modules/@putout/plugin-split-assignment-expressions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-split-assignment-expressions/-/plugin-split-assignment-expressions-2.1.0.tgz",
+      "integrity": "sha512-bgdNJEJSY6RD/HQGw/172agdf9x6t4sLFpMx1dhlNSD85867R7GnedFcgK5otGyzdNZAPVGxz/sMeCzQGOmNXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-split-call-with-destructuring": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-split-call-with-destructuring/-/plugin-split-call-with-destructuring-1.0.0.tgz",
+      "integrity": "sha512-lsdUvM4loepUFiHBNWB3FPYNEkoTxcBvnbZQVNMZ1Pnv5pXMe76/upHe1TVhqsVm/2+FR9KW3mEQbFPy2zhKkA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-split-nested-destructuring": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-split-nested-destructuring/-/plugin-split-nested-destructuring-3.0.0.tgz",
+      "integrity": "sha512-f0iLhhD2T2v1PMetc/KRoFU/46buGOhtuKDLWTmc1A9LAJSL1YLPOgrleTnZZb6virchPt09GKfJrrXAhjzsDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/plugin-split-variable-declarations": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-split-variable-declarations/-/plugin-split-variable-declarations-4.0.0.tgz",
+      "integrity": "sha512-LqxpBIU2ldfUnLwIaPU2IkFFTbuB0CclSlGpp05u5xYo/B8L0iImqZu7rF41wCCxirSztrvldk1O8vULsfiGJA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=37"
+      }
+    },
+    "node_modules/@putout/plugin-tape": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-tape/-/plugin-tape-17.0.0.tgz",
+      "integrity": "sha512-9TVpIkt7/YUCfsyEq2OD4TLA8JELIeGeGcWNVD1Rmk5O/nx39VsvBURlhXX1LrDfQNxtYv/yICPg3AchWDuLgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.6"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-try-catch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-try-catch/-/plugin-try-catch-4.0.0.tgz",
+      "integrity": "sha512-ucJ0Qo8imalzjHsW/TmiEo//gqA/J6kEQbLY6nRlLsD/GeK9GehtMRwJCmTHgofsjXWUTDL5q6b8Xq3c3X4D/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=36"
+      }
+    },
+    "node_modules/@putout/plugin-types": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-types/-/plugin-types-7.0.0.tgz",
+      "integrity": "sha512-aoxpVOgX/ovrEbKJbrdQA8MQftUE2O/WflTFDwylr2dZsro/w8qMyCvmQSgEAxxaauFfaUo6mC9HKz40FA1byg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-typescript": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-typescript/-/plugin-typescript-11.1.0.tgz",
+      "integrity": "sha512-3g1HupC+8Db+Q52GvFPY6rvD1A3pHC++mo8p8gfP1xe1XXC+nBJnd4mAF2LnRFehzWx0IGUmv11gHTdClaroIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/plugin-webpack": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-webpack/-/plugin-webpack-3.0.0.tgz",
+      "integrity": "sha512-qYUUvasY7AuWYGVOSuSnxYOMBcbIFIt+MaesxLW5j3sE0I51BkyiA8RPS7nUTW3nuzRt4TnzSdHS66RC6VO7nw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/printer": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@putout/printer/-/printer-13.4.1.tgz",
+      "integrity": "sha512-c5pCyU5TKy4gmev/+Uv7mB8YXDWLjKsx0/TSgua2lH/u7i6Xbd8c+TGLiDIn35ski1s8FkYLPnYCGIm4hEgI+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/compare": "^16.0.1",
+        "@putout/operate": "^13.0.0",
+        "@putout/operator-json": "^2.0.0",
+        "fullstore": "^3.0.0",
+        "just-snake-case": "^3.2.0",
+        "parse-import-specifiers": "^1.0.1",
+        "rendy": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/processor-css": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/processor-css/-/processor-css-10.0.1.tgz",
+      "integrity": "sha512-o/rTO2GR2M9Z1fSpAKrFMPPNwWCRcBufL1nDLWIwW1ExjW/VmaMWNh2HQP+vmyjsE9J/90/AEEDzyOrAegtXcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stylistic/stylelint-plugin": "^3.1.2",
+        "align-spaces": "^2.0.0",
+        "cosmiconfig": "^9.0.0",
+        "deepmerge": "^4.2.2",
+        "stylelint": "^16.0.1",
+        "stylelint-config-standard": "^37.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "putout": ">=38"
+      }
+    },
+    "node_modules/@putout/processor-filesystem": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/processor-filesystem/-/processor-filesystem-5.1.0.tgz",
+      "integrity": "sha512-ry+qQrg4ARNMCwE7Saae4Ddsyvv+a5z9v/GrvewkBraf4lxdZ8QYHFPqwJwPf3LJWIwII1KeSa5A9L/vTlv3LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/cli-filesystem": "^2.0.1",
+        "@putout/operator-filesystem": "^6.0.2",
+        "@putout/operator-json": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/processor-ignore": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/processor-ignore/-/processor-ignore-6.0.1.tgz",
+      "integrity": "sha512-f1kFzaBUIZyuRiX78SwMMPSQx+Fvspf69TmMUFYJqLkhKJ8I+F5IR0JmYHnorjfnPaEM5veVQd21wmyWCELRMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/operator-json": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/processor-javascript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/processor-javascript/-/processor-javascript-5.0.0.tgz",
+      "integrity": "sha512-0V2S2GTtzSXo1rLwCnEplVYZnAC2e2jdmSUig1p9qx9FjQj4MHCEHsmRjKkjh0NsajKUY5t2Z+ZLZ6GeagUlxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "putout": ">=29"
+      }
+    },
+    "node_modules/@putout/processor-json": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/processor-json/-/processor-json-9.0.0.tgz",
+      "integrity": "sha512-npJAD1WQ5niXgIvcU33CrmaOLLf90gHcDP1x9wrJhsdf3LQVAZFVDNIh9AhNI46TiL2fOxkp3rytuZIqzWBEwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/operator-json": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/processor-markdown": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/processor-markdown/-/processor-markdown-12.2.0.tgz",
+      "integrity": "sha512-tUojss3qDZdZKAWDehOXQxK4obXkKvoFwO3MvafFu73s/4R+f6KQ8YSzvxR8iT4h90HLXMegMgk7t0e6oSNkYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/operator-json": "^2.0.0",
+        "once": "^1.4.0",
+        "remark-frontmatter": "^5.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-preset-lint-consistent": "^6.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.3",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/processor-yaml": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/processor-yaml/-/processor-yaml-8.1.0.tgz",
+      "integrity": "sha512-byEG+EnjpFZFwrig1oG9cE2yBscCk8bPvO+qlqCFI0ztlYD40KK6ZN7LcYdQXmImwgRNHCxPvyD4L/eyjOl5OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/operator-json": "^2.0.0",
+        "just-kebab-case": "^4.0.2",
+        "try-catch": "^3.0.0",
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/quick-lint": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@putout/quick-lint/-/quick-lint-1.6.0.tgz",
+      "integrity": "sha512-PfgaX+QmFLfYy1gEnfhFvB7H3B+UtLgNtU5U+gmiY2h1yGyYmgljSKfK646fT6jSrBU1hpfcuAMH5SVVFTJZAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      },
+      "bin": {
+        "quick-lint": "bin/quick-lint.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@putout/traverse": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/traverse/-/traverse-12.0.0.tgz",
+      "integrity": "sha512-ckENZsjoXGQvz0dteWKLHJ5SmGGGeQoEwCyiBN73YLjRLftiSlEAjkQxh7FAZPfflZ1Cy7TfSVMKle7cXGpnpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/compare": "^16.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@smithy/abort-controller": {
@@ -2026,11 +4678,230 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@stylistic/stylelint-plugin": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-3.1.3.tgz",
+      "integrity": "sha512-85fsmzgsIVmyG3/GFrjuYj6Cz8rAM7IZiPiXCMiSMfoDOC1lOrzrXPDk24WqviAghnPqGpx8b0caK2PuewWGFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.1",
+        "@csstools/css-tokenizer": "^3.0.1",
+        "@csstools/media-query-list-parser": "^3.0.1",
+        "is-plain-object": "^5.0.0",
+        "postcss": "^8.4.41",
+        "postcss-selector-parser": "^6.1.2",
+        "postcss-value-parser": "^4.2.0",
+        "style-search": "^0.1.0"
+      },
+      "engines": {
+        "node": "^18.12 || >=20.9"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.8.0"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/luxon": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
       "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
       "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-typescript": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz",
+      "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": ">=8.9.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/align-spaces": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/align-spaces/-/align-spaces-2.0.0.tgz",
+      "integrity": "sha512-X6gR58NCT6MeoAVbe14SsDySGGGcxyze8rE6s/tJNcOCezeEeQXTV6U89JHjyLDvlfZuB7XATIxrFAWjRBFAVg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "align-spaces": "bin/align-spaces.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -2040,6 +4911,25 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2067,6 +4957,31 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
       "license": "MIT"
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
@@ -2075,6 +4990,80 @@
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.1.tgz",
+      "integrity": "sha512-Fa2BZY0CS9F0PFc/6aVA6tgpOdw+hmv9dkZOlHXII5v5Hw+meJBIWDcPrG9q/dXxGcNbym5t77fzmawrBQfTmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.10.0",
+        "keyv": "^5.3.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
+      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/color": {
@@ -2118,12 +5107,61 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/common-path-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cron": {
       "version": "4.3.1",
@@ -2138,6 +5176,66 @@
         "node": ">=18.x"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
+      "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12 || >=16"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/currify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/currify/-/currify-4.0.0.tgz",
+      "integrity": "sha512-ABfH28PWp5oqqp31cLXJQdeMqoFNej9rJOu84wKhN3jPCH7FAZg3zY1MVI27PTFoqfPlxOyhGmh9PzOVv+yN2g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -2148,11 +5246,105 @@
         "node": "*"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -2169,6 +5361,13 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -2177,6 +5376,464 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
+      "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.30.1",
+        "@eslint/plugin-kit": "^0.3.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/eslint/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estrace": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/estrace/-/estrace-5.1.2.tgz",
+      "integrity": "sha512-og5m3V75TL1EABySdedhgTz2gGaftEI1sVKU4ja/7Yb9Tg2r/3JqAvJjsa5Pogf9qdnl0P5YVFzzb1oFgTg+lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "format-io": "^2.0.0",
+        "putout": "^38.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-to-babel": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/estree-to-babel/-/estree-to-babel-10.5.0.tgz",
+      "integrity": "sha512-NUBZPOopJNJFGHQg3kODfNWOJW7KgOQl1H2co348IsZ3z58MokyiQFsADFbGf/3Z/QumGzkvybe3y9rS84VTJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/events": {
@@ -2188,12 +5845,72 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-copy": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
       "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-redact": {
       "version": "3.5.0",
@@ -2210,6 +5927,23 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
@@ -2233,12 +5967,340 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.1.tgz",
+      "integrity": "sha512-zcmsHjg2B2zjuBgjdnB+9q0+cWcgWfykIcsDkWDB4GTPtl1eXUA+gTI6sO0u01AqK3cliHryTU55/b2Ow1hfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.10"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-5.0.0.tgz",
+      "integrity": "sha512-OuWNfjfP05JcpAP3JPgAKUhWefjMRfI5iAoSsvE24ANYWJaepAtlSgWECSVEuRgSXpyNEc9DJwG/TZpgcOqyig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "common-path-prefix": "^3.0.0",
+        "pkg-dir": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.2.0",
+        "path-exists": "^5.0.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.11.tgz",
+      "integrity": "sha512-zfOAns94mp7bHG/vCn9Ru2eDCmIxVQ5dELUHKjHfDEOJmHNzE+uGa6208kfkgmtym4a0FFjEuFksCXFacbVhSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^1.10.1",
+        "flatted": "^3.3.3",
+        "hookified": "^1.10.0"
+      }
+    },
+    "node_modules/flatlint": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/flatlint/-/flatlint-2.14.1.tgz",
+      "integrity": "sha512-upldm/i7dSt/REteS/c1Y0K4KCJWE5GuxfcQATcaGrZicia9npVLCaKVyqO7dIaSd7lgyuPKFB69V/dOpSBHKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/engine-loader": "^15.1.1",
+        "@putout/operator-keyword": "^2.0.0",
+        "debug": "^4.4.0",
+        "js-tokens": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/flatlint/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/format-io": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/format-io/-/format-io-2.0.0.tgz",
+      "integrity": "sha512-iQz8w2qr4f+doWBV6LsfScHbu1gXhccByjbmA1wjBTaKRhweH2baJL96UGR4C7Fjpr8zSkK7EXiLmbzZWTyQIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "currify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fullstore": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fullstore/-/fullstore-3.0.0.tgz",
+      "integrity": "sha512-EEIdG+HWpyygWRwSLIZy+x4u0xtghjHNfhQb0mI5825Mmjq6oFESFUY0hoZigEgd3KH8GX+ZOCK9wgmOiS7VBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/goldstein": {
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/goldstein/-/goldstein-5.27.0.tgz",
+      "integrity": "sha512-KrW1qLc/pceHh6JHPt8rFOXlqyJbJg7lB3bKrSXXSaCyd3akJg2QaJQcmQRmn3CvpUg+ENpLyS241nL6ufzyuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/plugin-declare": "^5.0.0",
+        "@putout/plugin-logical-expressions": "^7.0.0",
+        "@putout/plugin-try-catch": "^4.0.0",
+        "@putout/printer": "^13.0.0",
+        "acorn": "^8.7.1",
+        "acorn-typescript": "^1.4.13",
+        "estree-to-babel": "^10.1.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "putout": "^38.0.0",
+        "try-catch": "^3.0.1"
+      },
+      "bin": {
+        "gs": "bin/gs.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/help-me": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hookified": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.10.0.tgz",
+      "integrity": "sha512-dJw0492Iddsj56U1JsSTm9E/0B/29a1AuoSLRAte8vQg/kaTGF3IgjEWT8c8yG4cC10+HisE1x5QAwR0Xwc+DA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -2260,10 +6322,54 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -2271,6 +6377,115 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unc-path": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unc-path-regex": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jessy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jessy/-/jessy-4.1.0.tgz",
+      "integrity": "sha512-fcq7gQpQs/7EKl3r+titWyizLkYGhO+PtWYnZG5aVVVSnnJb+bQyXQi8JF4/PZygbxVISFC5Xzw72LbNrVNj7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -2282,11 +6497,172 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/just-camel-case": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-camel-case/-/just-camel-case-6.2.0.tgz",
+      "integrity": "sha512-ICenRLXwkQYLk3UyvLQZ+uKuwFVJ3JHFYFn7F2782G2Mv2hW8WPePqgdhpnjGaqkYtSVWnyCESZhGXUmY3/bEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/just-kebab-case": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/just-kebab-case/-/just-kebab-case-4.2.0.tgz",
+      "integrity": "sha512-p2BdO7o4BI+pMun3J+dhaOfYan5JsZrw9wjshRjkWY9+p+u+kKSMhNWYnot2yHDR9CSahZ9iT3dcqJ+V72qHMw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/just-snake-case": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/just-snake-case/-/just-snake-case-3.2.0.tgz",
+      "integrity": "sha512-iugHP9bSE0jOq3BzN0W0rdu/OOkFirPe8FtUw6v9y37UlbUDgJ1x4xiGNfUhI6mV9dc/paaifyiyn+F+mrm8gw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.4.tgz",
+      "integrity": "sha512-ypEvQvInNpUe+u+w8BIcPkQvEqXquyyibWE/1NB5T2BTzIpS5cGEV1LZskDzPSTvNAaT4+5FutvzlvnkxOSKlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.0.3"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/known-css-properties": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/luxon": {
       "version": "3.6.1",
@@ -2297,6 +6673,724 @@
         "node": ">=12"
       }
     },
+    "node_modules/mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-comment-marker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-comment-marker/-/mdast-comment-marker-3.0.0.tgz",
+      "integrity": "sha512-bt08sLmTNg00/UtVDiqZKocxqvQqqyQZAg1uaRuO/4ysXV5motg7RolF5o5yy/sY1rG0v2XgZEqFWho1+2UquA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-mdx-expression": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-heading-style": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-heading-style/-/mdast-util-heading-style-3.0.0.tgz",
+      "integrity": "sha512-tsUfM9Kj9msjlemA/38Z3pvraQay880E3zP2NgIthMoGcpU9bcPX9oSM6QC/+eFXGGB4ba+VCB1dKAPHB7Veug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -2305,6 +7399,90 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mock-import": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mock-import/-/mock-import-4.2.1.tgz",
+      "integrity": "sha512-pVg4L7ecqAxZ8kyP4Gmj5k9ZDk7LRVK5mjPRop+mc3+U1O9Py8iGoDE6FIZ+WttXXnGrE44EIjR0aYg2F24gyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estrace": "^5.0.0",
+        "putout": "^38.0.0",
+        "try-catch": "^3.0.0",
+        "try-to-catch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.6"
+      }
+    },
+    "node_modules/montag": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/montag/-/montag-1.2.1.tgz",
+      "integrity": "sha512-YFuR6t5KhDlmAnUmVSxGzNcpWqSDqxbd95tvnEnn7X9yFv7g3kDFoRjwyGayVdF/NNoWk7YW7IxUjilnGnoC5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nano-memoize": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/nano-memoize/-/nano-memoize-3.0.16.tgz",
+      "integrity": "sha512-JyK96AKVGAwVeMj3MoMhaSXaUNqgMbCRSQB3trUV8tYZfWEzqUBKdK1qJpfuNXgKeHOx1jv/IEYTM659ly7zUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/nessy": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/nessy/-/nessy-5.3.0.tgz",
+      "integrity": "sha512-KYIB48Vx32Tmpe1p5iyhLGJp7iVqi2220A+F7hUoQJT+XiyrW5pu0PU8QHb5eFzrt34bgpclgQPNQKvSmLjmWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -2324,6 +7502,150 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-import-specifiers": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/parse-import-specifiers/-/parse-import-specifiers-1.0.3.tgz",
+      "integrity": "sha512-jNtWL2DinOHUGnFEzeAyCJhacxwFkLzPnR3Foy3t2mOTIEgzZ3aaOakPw0PvoLaPZUy64CWYuhVFa/QkEMLJhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pino": {
@@ -2388,6 +7710,144 @@
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
       "license": "MIT"
     },
+    "node_modules/pkg-dir": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+      "integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-resolve-nested-selector": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
+      "integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -2414,6 +7874,217 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/putout": {
+      "version": "38.5.7",
+      "resolved": "https://registry.npmjs.org/putout/-/putout-38.5.7.tgz",
+      "integrity": "sha512-C92oyIb6oIzvRMUYmGCbMqBqjy3aLf6IdKJkWYoyxnnb0lLYjTscD4xPACZR7S72XeF+yqp7dltSkcLA5Vd36Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/babel": "^3.0.0",
+        "@putout/cli-cache": "^5.0.0",
+        "@putout/cli-choose-formatter": "^4.0.0",
+        "@putout/cli-keypress": "^2.0.0",
+        "@putout/cli-match": "^2.0.0",
+        "@putout/cli-process-file": "^2.0.0",
+        "@putout/cli-ruler": "^3.0.0",
+        "@putout/cli-staged": "^1.0.0",
+        "@putout/cli-validate-args": "^2.0.0",
+        "@putout/compare": "^16.0.0",
+        "@putout/engine-loader": "^15.0.0",
+        "@putout/engine-parser": "^12.0.0",
+        "@putout/engine-processor": "^13.0.0",
+        "@putout/engine-reporter": "^3.0.0",
+        "@putout/engine-runner": "^23.0.1",
+        "@putout/formatter-codeframe": "^8.0.0",
+        "@putout/formatter-dump": "^5.0.0",
+        "@putout/formatter-frame": "^7.0.0",
+        "@putout/formatter-json": "^2.0.0",
+        "@putout/formatter-json-lines": "^3.0.0",
+        "@putout/formatter-memory": "^4.0.0",
+        "@putout/formatter-progress": "^5.0.0",
+        "@putout/formatter-progress-bar": "^4.0.0",
+        "@putout/formatter-stream": "^5.0.0",
+        "@putout/formatter-time": "^3.0.0",
+        "@putout/operate": "^13.0.0",
+        "@putout/operator-add-args": "^10.0.0",
+        "@putout/operator-declare": "^11.0.0",
+        "@putout/operator-filesystem": "^6.0.0",
+        "@putout/operator-ignore": "^2.0.0",
+        "@putout/operator-json": "^2.0.0",
+        "@putout/operator-keyword": "^2.0.0",
+        "@putout/operator-match-files": "^6.0.1",
+        "@putout/operator-parens": "^1.0.0",
+        "@putout/operator-regexp": "^1.0.0",
+        "@putout/operator-rename-files": "^2.0.0",
+        "@putout/plugin-apply-arrow": "^2.0.0",
+        "@putout/plugin-apply-at": "^2.0.0",
+        "@putout/plugin-apply-destructuring": "^8.0.0",
+        "@putout/plugin-apply-dot-notation": "^2.0.0",
+        "@putout/plugin-apply-flat-map": "^2.0.0",
+        "@putout/plugin-apply-overrides": "^2.0.0",
+        "@putout/plugin-apply-shorthand-properties": "^6.0.0",
+        "@putout/plugin-apply-starts-with": "^1.0.0",
+        "@putout/plugin-apply-template-literals": "^4.0.0",
+        "@putout/plugin-browserlist": "^2.0.0",
+        "@putout/plugin-conditions": "^7.1.0",
+        "@putout/plugin-convert-apply-to-spread": "^4.0.0",
+        "@putout/plugin-convert-arguments-to-rest": "^3.0.0",
+        "@putout/plugin-convert-array-copy-to-slice": "^3.0.0",
+        "@putout/plugin-convert-assignment-to-arrow-function": "^1.0.0",
+        "@putout/plugin-convert-assignment-to-comparison": "^2.0.0",
+        "@putout/plugin-convert-assignment-to-declaration": "^2.0.0",
+        "@putout/plugin-convert-concat-to-flat": "^1.0.0",
+        "@putout/plugin-convert-const-to-let": "^4.0.0",
+        "@putout/plugin-convert-expression-to-params": "^1.0.0",
+        "@putout/plugin-convert-index-of-to-includes": "^2.0.0",
+        "@putout/plugin-convert-object-assign-to-merge-spread": "^6.0.0",
+        "@putout/plugin-convert-object-entries-to-array-entries": "^3.0.0",
+        "@putout/plugin-convert-quotes-to-backticks": "^4.0.1",
+        "@putout/plugin-convert-template-to-string": "^2.0.0",
+        "@putout/plugin-convert-to-arrow-function": "^4.0.0",
+        "@putout/plugin-coverage": "^1.0.0",
+        "@putout/plugin-declare": "^5.0.0",
+        "@putout/plugin-declare-before-reference": "^6.0.0",
+        "@putout/plugin-eslint": "^12.0.0",
+        "@putout/plugin-esm": "^2.0.0",
+        "@putout/plugin-extract-keywords-from-variables": "^2.0.0",
+        "@putout/plugin-extract-object-properties": "^9.0.0",
+        "@putout/plugin-extract-sequence-expressions": "^3.0.0",
+        "@putout/plugin-filesystem": "^8.0.0",
+        "@putout/plugin-for-of": "^8.0.0",
+        "@putout/plugin-generators": "^1.0.0",
+        "@putout/plugin-github": "^14.0.0",
+        "@putout/plugin-gitignore": "^6.0.0",
+        "@putout/plugin-labels": "^1.0.0",
+        "@putout/plugin-logical-expressions": "^7.0.0",
+        "@putout/plugin-madrun": "^20.0.0",
+        "@putout/plugin-math": "^3.0.0",
+        "@putout/plugin-maybe": "^3.0.0",
+        "@putout/plugin-merge-destructuring-properties": "^10.0.0",
+        "@putout/plugin-merge-duplicate-functions": "^2.0.0",
+        "@putout/plugin-montag": "^3.0.0",
+        "@putout/plugin-new": "^3.0.1",
+        "@putout/plugin-nodejs": "^14.0.0",
+        "@putout/plugin-npmignore": "^5.0.0",
+        "@putout/plugin-optional-chaining": "^1.0.1",
+        "@putout/plugin-package-json": "^9.0.0",
+        "@putout/plugin-parens": "^2.0.0",
+        "@putout/plugin-promises": "^16.0.0",
+        "@putout/plugin-putout": "^23.0.0",
+        "@putout/plugin-putout-config": "^8.0.0",
+        "@putout/plugin-regexp": "^10.0.0",
+        "@putout/plugin-remove-console": "^6.0.0",
+        "@putout/plugin-remove-constant-conditions": "^4.0.0",
+        "@putout/plugin-remove-debugger": "^7.0.0",
+        "@putout/plugin-remove-duplicate-case": "^3.0.0",
+        "@putout/plugin-remove-duplicate-keys": "^7.0.0",
+        "@putout/plugin-remove-empty": "^14.0.0",
+        "@putout/plugin-remove-iife": "^4.0.0",
+        "@putout/plugin-remove-nested-blocks": "^8.0.0",
+        "@putout/plugin-remove-unreachable-code": "^2.0.0",
+        "@putout/plugin-remove-unreferenced-variables": "^5.0.0",
+        "@putout/plugin-remove-unused-expressions": "^11.0.0",
+        "@putout/plugin-remove-unused-for-of-variables": "^3.0.0",
+        "@putout/plugin-remove-unused-labels": "^1.0.1",
+        "@putout/plugin-remove-unused-private-fields": "^3.0.0",
+        "@putout/plugin-remove-unused-variables": "^12.0.0",
+        "@putout/plugin-remove-useless-arguments": "^11.0.0",
+        "@putout/plugin-remove-useless-array": "^1.0.0",
+        "@putout/plugin-remove-useless-array-constructor": "^2.0.0",
+        "@putout/plugin-remove-useless-array-entries": "^1.0.0",
+        "@putout/plugin-remove-useless-assign": "^1.0.0",
+        "@putout/plugin-remove-useless-constructor": "^2.0.0",
+        "@putout/plugin-remove-useless-continue": "^2.0.0",
+        "@putout/plugin-remove-useless-delete": "^1.0.1",
+        "@putout/plugin-remove-useless-escape": "^7.0.0",
+        "@putout/plugin-remove-useless-functions": "^4.0.0",
+        "@putout/plugin-remove-useless-map": "^1.0.0",
+        "@putout/plugin-remove-useless-operand": "^2.0.0",
+        "@putout/plugin-remove-useless-push": "^1.0.0",
+        "@putout/plugin-remove-useless-replace": "^1.0.1",
+        "@putout/plugin-remove-useless-spread": "^12.0.0",
+        "@putout/plugin-remove-useless-template-expressions": "^2.0.0",
+        "@putout/plugin-remove-useless-variables": "^13.0.0",
+        "@putout/plugin-return": "^1.0.0",
+        "@putout/plugin-reuse-duplicate-init": "^7.0.0",
+        "@putout/plugin-simplify-assignment": "^3.0.0",
+        "@putout/plugin-simplify-ternary": "^7.0.0",
+        "@putout/plugin-split-assignment-expressions": "^2.0.0",
+        "@putout/plugin-split-call-with-destructuring": "^1.0.0",
+        "@putout/plugin-split-nested-destructuring": "^3.0.0",
+        "@putout/plugin-split-variable-declarations": "^4.0.0",
+        "@putout/plugin-tape": "^17.0.0",
+        "@putout/plugin-try-catch": "^4.0.0",
+        "@putout/plugin-types": "^7.0.0",
+        "@putout/plugin-typescript": "^11.0.0",
+        "@putout/plugin-webpack": "^3.0.0",
+        "@putout/processor-css": "^10.0.0",
+        "@putout/processor-filesystem": "^5.0.0",
+        "@putout/processor-ignore": "^6.0.0",
+        "@putout/processor-javascript": "^5.0.0",
+        "@putout/processor-json": "^9.0.0",
+        "@putout/processor-markdown": "^12.0.0",
+        "@putout/processor-yaml": "^8.0.0",
+        "@putout/traverse": "^12.0.0",
+        "ajv": "^8.8.2",
+        "chalk": "^5.3.0",
+        "ci-info": "^4.0.0",
+        "debug": "^4.1.1",
+        "deepmerge": "^4.0.0",
+        "escalade": "^3.1.1",
+        "fast-glob": "^3.2.2",
+        "find-up": "^7.0.0",
+        "fullstore": "^3.0.0",
+        "ignore": "^7.0.0",
+        "is-relative": "^1.0.0",
+        "nano-memoize": "^3.0.11",
+        "once": "^1.4.0",
+        "picomatch": "^4.0.2",
+        "try-catch": "^3.0.0",
+        "try-to-catch": "^3.0.0",
+        "wraptile": "^3.0.0",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "putout": "bin/tracer.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
@@ -2444,6 +8115,451 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint/-/remark-lint-10.0.1.tgz",
+      "integrity": "sha512-1+PYGFziOg4pH7DDf1uMd4AR3YuO2EMnds/SdIWMPGT7CAfDRSnAmpxPsJD0Ds3IKpn97h3d5KPGf1WFOg6hXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "remark-message-control": "^8.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-blockquote-indentation": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-blockquote-indentation/-/remark-lint-blockquote-indentation-4.0.1.tgz",
+      "integrity": "sha512-7BhOsImFgTD7IIliu2tt+yJbx5gbMbXCOspc3VdYf/87iLJdWKqJoMy2V6DZG7kBjBlBsIZi38fDDngJttXt4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "pluralize": "^8.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-checkbox-character-style": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-checkbox-character-style/-/remark-lint-checkbox-character-style-5.0.1.tgz",
+      "integrity": "sha512-6qilm7XQXOcTvjFEqqNY57Ki7md9rkSdpMIfIzVXdEnI4Npl2BnUff6ANrGRM7qTgJTrloaf8H0eQ91urcU6Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-code-block-style": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-code-block-style/-/remark-lint-code-block-style-4.0.1.tgz",
+      "integrity": "sha512-d4mHsEpv1yqXWl2dd+28tGRX0Lzk5qw7cfxAQVkOXPUONhsMFwXJEBeeqZokeG4lOKtkKdIJR7ezScDfWR0X4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-emphasis-marker": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-emphasis-marker/-/remark-lint-emphasis-marker-4.0.1.tgz",
+      "integrity": "sha512-BF1WWsAxai3XoKk48sfiqT3L8m02AZLj3BnipWkHDRXuLfz6VwsHVaHWyNvvE0p6b2B3A5dSYbcfJu5RmPx4tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-fenced-code-marker": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-fenced-code-marker/-/remark-lint-fenced-code-marker-4.0.1.tgz",
+      "integrity": "sha512-uI91OcVPKjNxV+vpjDW9T64hkE0a/CRn3JhwdMxUAJYpVsKnA7PFPSFJOx/abNsVZHNSe7ZFGgGdaH/lqgSizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-heading-style": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-heading-style/-/remark-lint-heading-style-4.0.1.tgz",
+      "integrity": "sha512-+rUpJ/N2CGC5xPgZ18XgsCsUBtadgEhdTi0BJPrsFmHPzL22BUHajeg9im8Y7zphUcbi1qFiKuxZd2nzDgZSXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-heading-style": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-link-title-style": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-link-title-style/-/remark-lint-link-title-style-4.0.1.tgz",
+      "integrity": "sha512-MtmnYrhjhRXR0zeiyYf/7GBlUF5KAPypJb345KjyDluOhI4Wj4VAXvVQuov/MFc3y8p/1yVwv3QDYv6yue8/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-list-item-content-indent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-list-item-content-indent/-/remark-lint-list-item-content-indent-4.0.1.tgz",
+      "integrity": "sha512-KSopxxp64O6dLuTQ2sWaTqgjKWr1+AoB1QCTektMJ3mfHfn0QyZzC2CZbBU22KGzBhiYXv9cIxlJlxUtq2NqHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "pluralize": "^8.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-ordered-list-marker-style": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-style/-/remark-lint-ordered-list-marker-style-4.0.1.tgz",
+      "integrity": "sha512-vZTAbstcBPbGwJacwldGzdGmKwy5/4r29SZ9nQkME4alEl5B1ReSBlYa8t7QnTSW7+tqvA9Sg71RPadgAKWa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "micromark-util-character": "^2.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-ordered-list-marker-value": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-value/-/remark-lint-ordered-list-marker-value-4.0.1.tgz",
+      "integrity": "sha512-HQb1MrArvApREC1/I6bkiFlZVDjngsuII29n8E8StnAaHOMN3hVYy6wJ9Uk+O3+X9O8v7fDsZPqFUHSfJhERXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "micromark-util-character": "^2.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-rule-style": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-rule-style/-/remark-lint-rule-style-4.0.1.tgz",
+      "integrity": "sha512-gl1Ft13oTS3dJUCsWZzxD/5dAwI1HON67KU7uNfODD5gXJ8Y11deOWbun190ma7XbYdD7P0l8VT2HeRtEQzrWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-strong-marker": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-strong-marker/-/remark-lint-strong-marker-4.0.1.tgz",
+      "integrity": "sha512-KaGtj/OWEP4eoafevnlp3NsEVwC7yGEjBJ6uFMzfjNoXyjATdfZ2euB/AfKVt/A/FdZeeMeVoAUFH4DL+hScLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-table-cell-padding": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-5.1.1.tgz",
+      "integrity": "sha512-6fgVA1iINBoAJaZMOnSsxrF9Qj9+hmCqrsrqZqgJJETjT1ODGH64iAN1/6vHR7dIwmy73d6ysB2WrGyKhVlK3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "pluralize": "^8.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-message-control": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark-message-control/-/remark-message-control-8.0.0.tgz",
+      "integrity": "sha512-brpzOO+jdyE/mLqvqqvbogmhGxKygjpCUCG/PwSCU43+JZQ+RM+sSzkCWBcYvgF3KIAVNIoPsvXjBkzO7EdsYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-comment-marker": "^3.0.0",
+        "unified-message-control": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-preset-lint-consistent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-consistent/-/remark-preset-lint-consistent-6.0.1.tgz",
+      "integrity": "sha512-SOLdA36UOU1hiGFm6HAqN9+DORGJPVWxU/EvPVkknTr9V4ULhlzHEJ8OVRMVX3jqoy4lrwb4IqiboVz0YLA7+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remark-lint": "^10.0.0",
+        "remark-lint-blockquote-indentation": "^4.0.0",
+        "remark-lint-checkbox-character-style": "^5.0.0",
+        "remark-lint-code-block-style": "^4.0.0",
+        "remark-lint-emphasis-marker": "^4.0.0",
+        "remark-lint-fenced-code-marker": "^4.0.0",
+        "remark-lint-heading-style": "^4.0.0",
+        "remark-lint-link-title-style": "^4.0.0",
+        "remark-lint-list-item-content-indent": "^4.0.0",
+        "remark-lint-ordered-list-marker-style": "^4.0.0",
+        "remark-lint-ordered-list-marker-value": "^4.0.0",
+        "remark-lint-rule-style": "^4.0.0",
+        "remark-lint-strong-marker": "^4.0.0",
+        "remark-lint-table-cell-padding": "^5.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remove-blank-lines": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/remove-blank-lines/-/remove-blank-lines-1.4.2.tgz",
+      "integrity": "sha512-B8ru6S9sbP9AtXa14Mz1lYeiSPaG2UCu6yPT17QRLJnkk5RDPSe5f35RshaNpCTgiYEndIGgPzXxuB6Ayqjd/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rendy": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/rendy/-/rendy-4.1.3.tgz",
+      "integrity": "sha512-ljyvSWWFaPvncY+C/0GlpRh6f2Ufe1fhZwAVkqTHi/EvZjWM1PumqWJzFY5dBRBvXGnxxvWzDasK7UihddJfmg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2471,6 +8587,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/samadhi": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/samadhi/-/samadhi-2.15.1.tgz",
+      "integrity": "sha512-lqisprJcRKWHR+NWlOFBhoT0OF3zyqyqDsRfBklDGDEOkUzCG2rc7XA8/qg2sKYTA/uM5hJBfBaK5obzl1sHqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@putout/quick-lint": "^1.2.0",
+        "flatlint": "^2.0.0",
+        "goldstein": "^5.16.0",
+        "try-catch": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/secure-json-parse": {
@@ -2533,6 +8665,44 @@
         "@img/sharp-win32-x64": "0.34.2"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -2542,6 +8712,34 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
@@ -2549,6 +8747,27 @@
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/split2": {
@@ -2579,6 +8798,41 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2604,6 +8858,256 @@
       ],
       "license": "MIT"
     },
+    "node_modules/style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/stylelint": {
+      "version": "16.21.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.21.1.tgz",
+      "integrity": "sha512-WCXdXnYK2tpCbebgMF0Bme3YZH/Rh/UXerj75twYo4uLULlcrLwFVdZTvTEF8idFnAcW21YUDJFyKOfaf6xJRw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/media-query-list-parser": "^4.0.3",
+        "@csstools/selector-specificity": "^5.0.0",
+        "@dual-bundle/import-meta-resolve": "^4.1.0",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.0",
+        "css-functions-list": "^3.2.3",
+        "css-tree": "^3.1.0",
+        "debug": "^4.4.1",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^10.1.1",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.3.1",
+        "ignore": "^7.0.5",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.37.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^13.2.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.6",
+        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.0",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "supports-hyperlinks": "^3.2.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-15.0.0.tgz",
+      "integrity": "sha512-9LejMFsat7L+NXttdHdTq94byn25TD+82bzGRiV1Pgasl99pWnwipXS5DguTpp3nP1XjvLXVnEJIuYBfsRjRkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.13.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "37.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-37.0.0.tgz",
+      "integrity": "sha512-+6eBlbSTrOn/il2RlV0zYGQwRTkr+WtzuVSs1reaWGObxnxLpbcspCUYajVQHonVfxVw2U+h42azGhrBvcg8OA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "stylelint-config-recommended": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.13.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/@csstools/media-query-list-parser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+      "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/balanced-match": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylelint/node_modules/postcss-selector-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/stylelint/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -2613,11 +9117,241 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/timer-node": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/timer-node/-/timer-node-5.0.9.tgz",
+      "integrity": "sha512-zXxCE/5/YDi0hY9pygqgRqjRbrFRzigYxOudG0I3syaqAAmX9/w9sxex1bNFCN6c1S66RwPtEIJv65dN+1psew==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/try-catch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/try-catch/-/try-catch-3.0.1.tgz",
+      "integrity": "sha512-91yfXw1rr/P6oLpHSyHDOHm0vloVvUoo9FVdw8YwY05QjJQG9OT0LUxe2VRAzmHG+0CUOmI3nhxDUMLxDN/NEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/try-to-catch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/try-to-catch/-/try-to-catch-3.0.1.tgz",
+      "integrity": "sha512-hOY83V84Hx/1sCzDSaJA+Xz2IIQOHRvjxzt+F0OjbQGPZ6yLPLArMA0gw/484MlfUkQbCpKYMLX3VDCAjWKfzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified-lint-rule": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/unified-lint-rule/-/unified-lint-rule-3.0.1.tgz",
+      "integrity": "sha512-HxIeQOmwL19DGsxHXbeyzKHBsoSCFO7UtRVUvT2v61ptw/G+GbysWcrpHdfs5jqbIFDA11MoKngIhQK0BeTVjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "trough": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified-message-control": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unified-message-control/-/unified-message-control-5.0.0.tgz",
+      "integrity": "sha512-B2cSAkpuMVVmPP90KCfKdBhm1e9KYJ+zK3x5BCa0N65zpq1Ybkc9C77+M5qwR8FWO7RF3LM5QRRPZtgjW6DUCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -2638,12 +9372,153 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/wraptile": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wraptile/-/wraptile-3.0.0.tgz",
+      "integrity": "sha512-23LJhkIw940uTcDFyJZmNyO0z8lEINOTGCr4vR5YCG3urkdXwduRIhivBm9wKaVynLHYvxoHHYbKsDiafCLp6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "node index.js | pino-pretty",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "node index.js | pino-pretty",
-    "test": "node --test"
+    "test": "node --test --import mock-import/register"
   },
   "repository": {
     "type": "git",
@@ -37,6 +37,7 @@
     "sharp": "0.34.2"
   },
   "devDependencies": {
+    "mock-import": "4.2.1",
     "pino-pretty": "13.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "node index.js | pino-pretty",
-    "test": "node --test --import mock-import/register"
+    "test": "LOG_LEVEL=silent node --test --import mock-import/register"
   },
   "repository": {
     "type": "git",

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -1,0 +1,28 @@
+import minify from "./minify.js";
+import smallify from "./smallify.js";
+import mediumify from "./mediumify.js";
+import largify from "./largify.js";
+
+/**
+ * @typedef {import('sharp').Sharp} Sharp
+ * @typedef {function(Sharp): Sharp} TransformerFunction
+ */
+
+/**
+ * @typedef {object} TransformerMap
+ * @property {TransformerFunction} [key]
+ */
+
+/**
+ * Map of all available image transformation tasks.
+ * Each task configures a Sharp instance for a specific transformation.
+ *
+ * @type {TransformerMap}
+ * @default
+ */
+export default {
+  ...minify,
+  ...smallify,
+  ...mediumify,
+  ...largify,
+};

--- a/tasks/index.test.js
+++ b/tasks/index.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import tasks from "./index.js";
+
+test("tasks:index", async (t) => {
+  await t.test("exports", async () => {
+    assert.equal(typeof tasks, "object", "should export an object");
+    const actualKeys = Object.keys(tasks).sort();
+
+    const expectedKeys = ["-min", "-sm", "-md", "-lg"].sort();
+
+    assert.deepEqual(
+      actualKeys,
+      expectedKeys,
+      "should export all transformation tasks"
+    );
+
+    // Verify each is a function
+    for (const key of expectedKeys) {
+      assert.equal(
+        typeof tasks[key],
+        "function",
+        `${key} should be a function`
+      );
+    }
+  });
+});

--- a/tasks/largify.js
+++ b/tasks/largify.js
@@ -1,0 +1,29 @@
+/** @module tasks/largify */
+
+/**
+ * @typedef {import('sharp').Sharp} Sharp
+ */
+
+/**
+ * @typedef {function(Sharp): Sharp} TransformerFunction
+ */
+
+/**
+ * @typedef {object} TransformerMap
+ * @property {TransformerFunction} "-lg" - Largify transformer function
+ */
+
+/**
+ * Largify transformer - resizes image to large width (1920px)
+ *
+ * @type {TransformerMap}
+ * @default
+ */
+export default {
+  "-lg": function largify(sharp) {
+    return sharp.resize(1920, null, {
+      fit: "inside",
+      withoutEnlargement: true,
+    }).jpeg({ quality: 90 });
+  },
+};

--- a/tasks/largify.test.js
+++ b/tasks/largify.test.js
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert";
+import sharp from "sharp";
+
+import largifyTask from "./largify.js";
+
+test("tasks/largify", async (t) => {
+  await t.test("exports", () => {
+    assert.equal(typeof largifyTask, "object", "should export an object");
+    assert.ok(largifyTask["-lg"], "should have -lg property");
+    assert.equal(
+      typeof largifyTask["-lg"],
+      "function",
+      "should export a function"
+    );
+  });
+
+  await t.test("returns configured Sharp instance", () => {
+    const sharpInstance = sharp();
+    const result = largifyTask["-lg"](sharpInstance);
+
+    assert.ok(result, "should return a value");
+    assert.equal(
+      result.constructor.name,
+      "Sharp",
+      "should return a Sharp instance"
+    );
+  });
+
+  await t.test("resizes to 1920px width maintaining aspect ratio", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 4000,
+        height: 3000,
+        channels: 4,
+        background: { r: 255, g: 255, b: 0, alpha: 1 },
+      },
+    }).jpeg();
+
+    const sharpInstance = sharp();
+    const transformer = largifyTask["-lg"];
+    const configured = transformer(sharpInstance);
+
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    const metadata = await sharp(result).metadata();
+    assert.equal(metadata.width, 1920, "should resize to 1920px width");
+    // Height should be proportionally scaled: 3000 * (1920/4000) = 1440
+    assert.equal(
+      metadata.height,
+      1440,
+      "should maintain aspect ratio (1440px height)"
+    );
+    assert.equal(metadata.format, "jpeg", "should convert to JPEG format");
+  });
+
+  await t.test("does not enlarge smaller images", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 1600,
+        height: 1200,
+        channels: 4,
+        background: { r: 255, g: 255, b: 0, alpha: 1 },
+      },
+    }).jpeg();
+
+    const sharpInstance = sharp();
+    const transformer = largifyTask["-lg"];
+    const configured = transformer(sharpInstance);
+
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    const metadata = await sharp(result).metadata();
+    assert.equal(
+      metadata.width,
+      1600,
+      "should not enlarge (withoutEnlargement: true)"
+    );
+    assert.equal(metadata.height, 1200, "should maintain original height");
+  });
+
+  await t.test("applies quality settings", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 3000,
+        height: 2000,
+        channels: 4,
+        background: { r: 255, g: 255, b: 0, alpha: 1 },
+      },
+    }).jpeg();
+
+    const sharpInstance = sharp();
+    const transformer = largifyTask["-lg"];
+    const configured = transformer(sharpInstance);
+
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    assert.ok(result.length > 0, "should produce output");
+    assert.ok(result.length < 250000, "should compress with quality: 90");
+  });
+});

--- a/tasks/mediumify.js
+++ b/tasks/mediumify.js
@@ -1,0 +1,29 @@
+/** @module tasks/mediumify */
+
+/**
+ * @typedef {import('sharp').Sharp} Sharp
+ */
+
+/**
+ * @typedef {function(Sharp): Sharp} TransformerFunction
+ */
+
+/**
+ * @typedef {object} TransformerMap
+ * @property {TransformerFunction} "-md" - Mediumify transformer function
+ */
+
+/**
+ * Mediumify transformer - resizes image to medium width (1024px)
+ *
+ * @type {TransformerMap}
+ * @default
+ */
+export default {
+  "-md": function mediumify(sharp) {
+    return sharp.resize(1024, null, {
+      fit: "inside",
+      withoutEnlargement: true,
+    }).jpeg({ quality: 88 });
+  },
+};

--- a/tasks/mediumify.test.js
+++ b/tasks/mediumify.test.js
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert";
+import sharp from "sharp";
+
+import mediumifyTask from "./mediumify.js";
+
+test("tasks/mediumify", async (t) => {
+  await t.test("exports", () => {
+    assert.equal(typeof mediumifyTask, "object", "should export an object");
+    assert.ok(mediumifyTask["-md"], "should have -md property");
+    assert.equal(
+      typeof mediumifyTask["-md"],
+      "function",
+      "should export a function"
+    );
+  });
+
+  await t.test("returns configured Sharp instance", () => {
+    const sharpInstance = sharp();
+    const result = mediumifyTask["-md"](sharpInstance);
+
+    assert.ok(result, "should return a value");
+    assert.equal(
+      result.constructor.name,
+      "Sharp",
+      "should return a Sharp instance"
+    );
+  });
+
+  await t.test("resizes to 1024px width maintaining aspect ratio", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 3000,
+        height: 2000,
+        channels: 4,
+        background: { r: 0, g: 0, b: 255, alpha: 1 },
+      },
+    }).jpeg();
+
+    const sharpInstance = sharp();
+    const transformer = mediumifyTask["-md"];
+    const configured = transformer(sharpInstance);
+
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    const metadata = await sharp(result).metadata();
+    assert.equal(metadata.width, 1024, "should resize to 1024px width");
+    // Height should be proportionally scaled: 2000 * (1024/3000) ≈ 683
+    assert.ok(
+      Math.abs(metadata.height - 683) <= 1,
+      "should maintain aspect ratio (~683px height)"
+    );
+    assert.equal(metadata.format, "jpeg", "should convert to JPEG format");
+  });
+
+  await t.test("does not enlarge smaller images", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 800,
+        height: 600,
+        channels: 4,
+        background: { r: 0, g: 0, b: 255, alpha: 1 },
+      },
+    }).jpeg();
+
+    const sharpInstance = sharp();
+    const transformer = mediumifyTask["-md"];
+    const configured = transformer(sharpInstance);
+
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    const metadata = await sharp(result).metadata();
+    assert.equal(
+      metadata.width,
+      800,
+      "should not enlarge (withoutEnlargement: true)"
+    );
+    assert.equal(metadata.height, 600, "should maintain original height");
+  });
+
+  await t.test("applies quality settings", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 2000,
+        height: 1500,
+        channels: 4,
+        background: { r: 0, g: 0, b: 255, alpha: 1 },
+      },
+    }).jpeg();
+
+    const sharpInstance = sharp();
+    const transformer = mediumifyTask["-md"];
+    const configured = transformer(sharpInstance);
+
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    assert.ok(result.length > 0, "should produce output");
+    assert.ok(result.length < 150000, "should compress with quality: 88");
+  });
+});

--- a/tasks/minify.js
+++ b/tasks/minify.js
@@ -1,0 +1,26 @@
+/** @module tasks/minify */
+
+/**
+ * @typedef {import('sharp').Sharp} Sharp
+ */
+
+/**
+ * @typedef {function(Sharp): Sharp} TransformerFunction
+ */
+
+/**
+ * @typedef {object} TransformerMap
+ * @property {TransformerFunction} "-min" - Minify transformer function
+ */
+
+/**
+ * Minify transformer - converts image to JPEG with mozjpeg compression
+ *
+ * @type {TransformerMap}
+ * @default
+ */
+export default {
+  "-min": function minify(sharp) {
+    return sharp.jpeg({ mozjpeg: true });
+  },
+};

--- a/tasks/minify.test.js
+++ b/tasks/minify.test.js
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert";
+import sharp from "sharp";
+
+import minifyTask from "./minify.js";
+
+test("tasks/minify", async (t) => {
+  await t.test("exports", () => {
+    assert.equal(typeof minifyTask, "object", "should export an object");
+    assert.ok(minifyTask["-min"], "should have -min property");
+    assert.equal(
+      typeof minifyTask["-min"],
+      "function",
+      "should export a function"
+    );
+  });
+
+  await t.test("returns configured Sharp instance", () => {
+    const sharpInstance = sharp();
+    const result = minifyTask["-min"](sharpInstance);
+
+    assert.ok(result, "should return a value");
+    assert.equal(
+      result.constructor.name,
+      "Sharp",
+      "should return a Sharp instance"
+    );
+  });
+
+  await t.test("applies JPEG mozjpeg transformation", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 500,
+        height: 300,
+        channels: 4,
+        background: { r: 255, g: 0, b: 0, alpha: 1 },
+      },
+    }).jpeg(); // Test with JPEG input since that's what production uses
+
+    const sharpInstance = sharp();
+    const transformer = minifyTask["-min"];
+    const configured = transformer(sharpInstance);
+
+    // Pipe the test image through the configured pipeline
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    // Verify the output
+    const metadata = await sharp(result).metadata();
+    assert.equal(metadata.format, "jpeg", "should convert to JPEG format");
+    assert.equal(metadata.width, 500, "should maintain width");
+    assert.equal(metadata.height, 300, "should maintain height");
+  });
+
+  await t.test("produces compressed output", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 500,
+        height: 300,
+        channels: 4,
+        background: { r: 255, g: 0, b: 0, alpha: 1 },
+      },
+    }).png(); // Start with PNG
+
+    const sharpInstance = sharp();
+    const transformer = minifyTask["-min"];
+    const configured = transformer(sharpInstance);
+
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    // JPEG with mozjpeg should produce a reasonably sized file
+    assert.ok(
+      result.length > 0,
+      "should produce output"
+    );
+    assert.ok(
+      result.length < 50000,
+      "should compress the image (mozjpeg)"
+    );
+  });
+});

--- a/tasks/smallify.js
+++ b/tasks/smallify.js
@@ -1,0 +1,29 @@
+/** @module tasks/smallify */
+
+/**
+ * @typedef {import('sharp').Sharp} Sharp
+ */
+
+/**
+ * @typedef {function(Sharp): Sharp} TransformerFunction
+ */
+
+/**
+ * @typedef {object} TransformerMap
+ * @property {TransformerFunction} "-sm" - Smallify transformer function
+ */
+
+/**
+ * Smallify transformer - resizes image to small width (640px)
+ *
+ * @type {TransformerMap}
+ * @default
+ */
+export default {
+  "-sm": function smallify(sharp) {
+    return sharp.resize(640, null, {
+      fit: "inside",
+      withoutEnlargement: true,
+    }).jpeg({ quality: 85 });
+  },
+};

--- a/tasks/smallify.test.js
+++ b/tasks/smallify.test.js
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert";
+import sharp from "sharp";
+
+import smallifyTask from "./smallify.js";
+
+test("tasks/smallify", async (t) => {
+  await t.test("exports", () => {
+    assert.equal(typeof smallifyTask, "object", "should export an object");
+    assert.ok(smallifyTask["-sm"], "should have -sm property");
+    assert.equal(
+      typeof smallifyTask["-sm"],
+      "function",
+      "should export a function"
+    );
+  });
+
+  await t.test("returns configured Sharp instance", () => {
+    const sharpInstance = sharp();
+    const result = smallifyTask["-sm"](sharpInstance);
+
+    assert.ok(result, "should return a value");
+    assert.equal(
+      result.constructor.name,
+      "Sharp",
+      "should return a Sharp instance"
+    );
+  });
+
+  await t.test("resizes to 640px width maintaining aspect ratio", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 2000,
+        height: 1500,
+        channels: 4,
+        background: { r: 0, g: 255, b: 0, alpha: 1 },
+      },
+    }).jpeg();
+
+    const sharpInstance = sharp();
+    const transformer = smallifyTask["-sm"];
+    const configured = transformer(sharpInstance);
+
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    const metadata = await sharp(result).metadata();
+    assert.equal(metadata.width, 640, "should resize to 640px width");
+    assert.equal(metadata.height, 480, "should maintain aspect ratio (480px height)");
+    assert.equal(metadata.format, "jpeg", "should convert to JPEG format");
+  });
+
+  await t.test("does not enlarge smaller images", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 400,
+        height: 300,
+        channels: 4,
+        background: { r: 0, g: 255, b: 0, alpha: 1 },
+      },
+    }).jpeg();
+
+    const sharpInstance = sharp();
+    const transformer = smallifyTask["-sm"];
+    const configured = transformer(sharpInstance);
+
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    const metadata = await sharp(result).metadata();
+    assert.equal(
+      metadata.width,
+      400,
+      "should not enlarge (withoutEnlargement: true)"
+    );
+    assert.equal(metadata.height, 300, "should maintain original height");
+  });
+
+  await t.test("applies quality settings", async () => {
+    const inputImage = sharp({
+      create: {
+        width: 1000,
+        height: 800,
+        channels: 4,
+        background: { r: 0, g: 255, b: 0, alpha: 1 },
+      },
+    }).jpeg();
+
+    const sharpInstance = sharp();
+    const transformer = smallifyTask["-sm"];
+    const configured = transformer(sharpInstance);
+
+    const result = await new Promise((resolve, reject) => {
+      const buffers = [];
+      inputImage.pipe(configured);
+
+      configured.on("data", (chunk) => buffers.push(chunk));
+      configured.on("end", () => {
+        resolve(Buffer.concat(buffers));
+      });
+      configured.on("error", reject);
+    });
+
+    assert.ok(result.length > 0, "should produce output");
+    assert.ok(result.length < 100000, "should compress with quality: 85");
+  });
+});

--- a/utils/fetchObject.js
+++ b/utils/fetchObject.js
@@ -22,7 +22,7 @@ export default async function fetchObject(key, options) {
   const { client, bucket } = options;
   const logger = getLogger("fetchObject");
 
-  logger.trace({ key, options }, "fetchObject:params");
+  logger.trace({ key, bucket, client: typeof client }, "fetchObject:params");
 
   const command = new GetObjectCommand({
     Bucket: bucket,

--- a/utils/groupDifferences.js
+++ b/utils/groupDifferences.js
@@ -1,0 +1,41 @@
+/**
+ * @typedef {object} GroupedItems
+ * @property {ObjectItem[]} unminified
+ * @property {ObjectItem[]} unsmall
+ * @property {ObjectItem[]} unmedium
+ * @property {ObjectItem[]} unlarge
+ */
+
+/**
+ * Object where the key is the `Key` of the item and the value is an array of
+ * the values from the `GROUPS` object.
+ * @typedef {Object.<string, string[]>} GroupedDifferences
+ */
+
+const GROUPS = {
+  unminified: "-min",
+  unsmall: "-sm",
+  unmedium: "-md",
+  unlarge: "-lg",
+};
+
+/**
+ * @param {ObjectItem[]} items
+ * @param {GroupedItems} groups
+ * @returns {GroupedDifferences}
+ */
+export default function groupDifferences(items = [], groups = {}) {
+  return items.reduce((acc, item) => {
+    if (!acc[item.Key]) {
+      acc[item.Key] = [];
+    }
+
+    for (const [group, identifier] of Object.entries(GROUPS)) {
+      if (groups[group].some((i) => item.Key === i.Key)) {
+        acc[item.Key] = acc[item.Key].concat(identifier);
+      }
+    }
+
+    return acc;
+  }, {});
+}

--- a/utils/groupDifferences.test.js
+++ b/utils/groupDifferences.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import groupDifferences from "./groupDifferences.js";
+
+const mockItems = [
+  { Key: "first.jpg" },
+  { Key: "second.jpg" },
+  { Key: "third.jpg" },
+  { Key: "forth.jpg" },
+  { Key: "fifth.jpg" },
+];
+
+const mockUnminified = [{ Key: "first.jpg" }];
+const mockUnsmall = [{ Key: "first.jpg" }, { Key: "second.jpg" }];
+const mockUnmedium = [{ Key: "first.jpg" }];
+const mockUnlarge = [{ Key: "first.jpg" }, { Key: "fifth.jpg" }];
+
+const mockGroups = {
+  unminified: mockUnminified,
+  unsmall: mockUnsmall,
+  unmedium: mockUnmedium,
+  unlarge: mockUnlarge,
+};
+
+test("groupDifferences", async (t) => {
+  await t.test("default return", async () => {
+    const expectedResult = {};
+    const actualResult = groupDifferences();
+    assert.deepEqual(actualResult, expectedResult);
+  });
+
+  await t.test("should group differences", async () => {
+    const expectedResult = {
+      "first.jpg": ["-min", "-sm", "-md", "-lg"],
+      "second.jpg": ["-sm"],
+      "third.jpg": [],
+      "forth.jpg": [],
+      "fifth.jpg": ["-lg"],
+    };
+    const actualResult = groupDifferences(mockItems, mockGroups);
+    assert.deepEqual(actualResult, expectedResult);
+  });
+});

--- a/utils/groupObjects.js
+++ b/utils/groupObjects.js
@@ -1,28 +1,40 @@
 /**
  * @typedef {object} GroupedObjects
  * @property {ObjectItem[]} minified
+ * @property {ObjectItem[]} small
+ * @property {ObjectItem[]} medium
+ * @property {ObjectItem[]} large
  * @property {ObjectItem[]} images
  */
+
+const GROUPS = {
+  minified: "-min",
+  small: "-sm",
+  medium: "-md",
+  large: "-lg",
+};
 
 /**
  * @param {OjectItem[]} items
  * @returns {GroupedObjects}
  */
 export default function groupObjects(items) {
-  const { minified, images } = items.reduce(
+  return items.reduce(
     (acc, item) => {
-      const isMinified = item.Key.indexOf("-min") !== -1;
-      if (isMinified) {
-        //INFO: minified image
-        const Key = item.Key.replace("-min", "");
-        acc.minified.push({ Key });
+      const grouping = Object.entries(GROUPS).find(
+        ([_group, slug]) => item.Key.indexOf(slug) !== -1,
+      );
+
+      if (grouping) {
+        const [group, slug] = grouping;
+        const Key = item.Key.replace(slug, "");
+        acc[group].push({ Key });
       } else {
         acc.images.push(item);
       }
+
       return acc;
     },
-    { minified: [], images: [] },
+    { minified: [], small: [], medium: [], large: [], images: [] },
   );
-
-  return { minified, images };
 }

--- a/utils/groupObjects.test.js
+++ b/utils/groupObjects.test.js
@@ -16,61 +16,276 @@ test("groupObjects", async (t) => {
     assert.deepEqual(actualResult, expectedResult);
   });
 
-  await t.test("should remove '-min' from key", async (t) => {
+  await t.test("groupings", async () => {
     const mockItems = [
-      {
-        Key: "first-min.jpg",
-      },
+      { Key: "first.jpg" },
+      { Key: "first-sm.jpg" },
+      { Key: "first-lg.jpg" },
+      { Key: "second.jpg" },
+      { Key: "second-min.jpg" },
+      { Key: "second-sm.jpg" },
+      { Key: "third.jpg" },
+      { Key: "third-md.jpg" },
+      { Key: "forth.jpg" },
+      { Key: "forth-lg.jpg" },
+      { Key: "fifth.jpg" },
     ];
 
     const expectedResult = {
-      minified: [
-        {
-          Key: "first.jpg",
-        },
+      minified: [{ Key: "second.jpg" }],
+      small: [{ Key: "first.jpg" }, { Key: "second.jpg" }],
+      medium: [{ Key: "third.jpg" }],
+      large: [{ Key: "first.jpg" }, { Key: "forth.jpg" }],
+      images: [
+        { Key: "first.jpg" },
+        { Key: "second.jpg" },
+        { Key: "third.jpg" },
+        { Key: "forth.jpg" },
+        { Key: "fifth.jpg" },
       ],
-      small: [],
-      medium: [],
-      large: [],
-      images: [],
     };
 
     const actualResult = groupObjects(mockItems);
     assert.deepEqual(actualResult, expectedResult);
   });
 
-  await t.test("should groups objects", async (t) => {
-    const mockItems = [
-      {
-        Key: "first.jpg",
-      },
-      {
-        Key: "second.jpg",
-      },
-      {
-        Key: "first-min.jpg",
-      },
-    ];
-
-    const expectedResult = {
-      minified: [
+  await t.test("large", async (t) => {
+    await t.test("should remove -lg from key", async (t) => {
+      const mockItems = [
         {
-          Key: "first.jpg",
+          Key: "first-lg.jpg",
         },
-      ],
-      small: [],
-      medium: [],
-      large: [],
-      images: [
+      ];
+
+      const expectedResult = {
+        minified: [],
+        small: [],
+        medium: [],
+        large: [
+          {
+            Key: "first.jpg",
+          },
+        ],
+        images: [],
+      };
+
+      const actualResult = groupObjects(mockItems);
+      assert.deepEqual(actualResult, expectedResult);
+    });
+
+    await t.test("should group large objects", async (t) => {
+      const mockItems = [
         {
           Key: "first.jpg",
         },
         {
           Key: "second.jpg",
         },
-      ],
-    };
-    const actualResult = groupObjects(mockItems);
-    assert.deepEqual(actualResult, expectedResult);
+        {
+          Key: "first-lg.jpg",
+        },
+      ];
+
+      const expectedResult = {
+        minified: [],
+        small: [],
+        medium: [],
+        large: [
+          {
+            Key: "first.jpg",
+          },
+        ],
+        images: [
+          {
+            Key: "first.jpg",
+          },
+          {
+            Key: "second.jpg",
+          },
+        ],
+      };
+      const actualResult = groupObjects(mockItems);
+      assert.deepEqual(actualResult, expectedResult);
+    });
+  });
+
+  await t.test("medium", async (t) => {
+    await t.test("should remove -md from key", async (t) => {
+      const mockItems = [
+        {
+          Key: "first-md.jpg",
+        },
+      ];
+
+      const expectedResult = {
+        minified: [],
+        small: [],
+        medium: [
+          {
+            Key: "first.jpg",
+          },
+        ],
+        large: [],
+        images: [],
+      };
+
+      const actualResult = groupObjects(mockItems);
+      assert.deepEqual(actualResult, expectedResult);
+    });
+
+    await t.test("should group medium objects", async (t) => {
+      const mockItems = [
+        {
+          Key: "first.jpg",
+        },
+        {
+          Key: "second.jpg",
+        },
+        {
+          Key: "first-md.jpg",
+        },
+      ];
+
+      const expectedResult = {
+        minified: [],
+        small: [],
+        medium: [
+          {
+            Key: "first.jpg",
+          },
+        ],
+        large: [],
+        images: [
+          {
+            Key: "first.jpg",
+          },
+          {
+            Key: "second.jpg",
+          },
+        ],
+      };
+      const actualResult = groupObjects(mockItems);
+      assert.deepEqual(actualResult, expectedResult);
+    });
+  });
+
+  await t.test("small", async (t) => {
+    await t.test("should remove -sm from key", async (t) => {
+      const mockItems = [
+        {
+          Key: "first-sm.jpg",
+        },
+      ];
+
+      const expectedResult = {
+        minified: [],
+        small: [
+          {
+            Key: "first.jpg",
+          },
+        ],
+        medium: [],
+        large: [],
+        images: [],
+      };
+
+      const actualResult = groupObjects(mockItems);
+      assert.deepEqual(actualResult, expectedResult);
+    });
+
+    await t.test("should group small objects", async (t) => {
+      const mockItems = [
+        {
+          Key: "first.jpg",
+        },
+        {
+          Key: "second.jpg",
+        },
+        {
+          Key: "first-sm.jpg",
+        },
+      ];
+
+      const expectedResult = {
+        minified: [],
+        small: [
+          {
+            Key: "first.jpg",
+          },
+        ],
+        medium: [],
+        large: [],
+        images: [
+          {
+            Key: "first.jpg",
+          },
+          {
+            Key: "second.jpg",
+          },
+        ],
+      };
+      const actualResult = groupObjects(mockItems);
+      assert.deepEqual(actualResult, expectedResult);
+    });
+  });
+
+  await t.test("minified", async (t) => {
+    await t.test("should remove '-min' from key", async (t) => {
+      const mockItems = [
+        {
+          Key: "first-min.jpg",
+        },
+      ];
+
+      const expectedResult = {
+        minified: [
+          {
+            Key: "first.jpg",
+          },
+        ],
+        small: [],
+        medium: [],
+        large: [],
+        images: [],
+      };
+
+      const actualResult = groupObjects(mockItems);
+      assert.deepEqual(actualResult, expectedResult);
+    });
+
+    await t.test("should group minified objects", async (t) => {
+      const mockItems = [
+        {
+          Key: "first.jpg",
+        },
+        {
+          Key: "second.jpg",
+        },
+        {
+          Key: "first-min.jpg",
+        },
+      ];
+
+      const expectedResult = {
+        minified: [
+          {
+            Key: "first.jpg",
+          },
+        ],
+        small: [],
+        medium: [],
+        large: [],
+        images: [
+          {
+            Key: "first.jpg",
+          },
+          {
+            Key: "second.jpg",
+          },
+        ],
+      };
+      const actualResult = groupObjects(mockItems);
+      assert.deepEqual(actualResult, expectedResult);
+    });
   });
 });

--- a/utils/groupObjects.test.js
+++ b/utils/groupObjects.test.js
@@ -5,8 +5,15 @@ import groupObjects from "./groupObjects.js";
 
 test("groupObjects", async (t) => {
   await t.test("default return", async (t) => {
+    const expectedResult = {
+      minified: [],
+      small: [],
+      medium: [],
+      large: [],
+      images: [],
+    };
     const actualResult = groupObjects([]);
-    assert.deepEqual(actualResult, { minified: [], images: [] });
+    assert.deepEqual(actualResult, expectedResult);
   });
 
   await t.test("should remove '-min' from key", async (t) => {
@@ -22,6 +29,9 @@ test("groupObjects", async (t) => {
           Key: "first.jpg",
         },
       ],
+      small: [],
+      medium: [],
+      large: [],
       images: [],
     };
 
@@ -48,6 +58,9 @@ test("groupObjects", async (t) => {
           Key: "first.jpg",
         },
       ],
+      small: [],
+      medium: [],
+      large: [],
       images: [
         {
           Key: "first.jpg",

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -7,7 +7,7 @@ export function getLogger(functionName) {
     return logger.child({ function: functionName });
   }
 
-  logger = createLogger();
+  logger = createLogger({});
 
   return logger.child({ function: functionName });
 }

--- a/utils/transformAndUpload.js
+++ b/utils/transformAndUpload.js
@@ -5,16 +5,6 @@ import sharp from "sharp";
 import { getLogger } from "./logger.js";
 
 /**
- * @param {Readable} stream
- */
-function handleStreamError(stream) {
-  return (err) => {
-    console.error("error:", err);
-    stream.emit("error", err);
-  };
-}
-
-/**
  * @typedef {object} ImageObject
  * @property {string} ContentType
  * @property {Object.<string, string>} Metadata
@@ -23,49 +13,108 @@ function handleStreamError(stream) {
  */
 
 /**
- * @param {ImageObject} imageObject
- * @param {object} options
- * @param {S3}     options.client - S3 client instance
- * @param {string} options.bucket - Name of the bucket
+ * @typedef {import('sharp').Sharp} Sharp
+ * @typedef {function(Sharp): Sharp} TransformerFunction
+ * @typedef {Object.<string, TransformerFunction>} Transformer
+ */
+
+/**
+ * Transforms an image using multiple transformers in parallel and uploads each result.
+ * Uses streams to avoid loading entire images into memory.
+ *
+ * @param {ImageObject} imageObject - The image object with stream and metadata
+ * @param {object}   options
+ * @param {S3}       options.client - S3 client instance
+ * @param {string}   options.bucket - Name of the bucket
+ * @param {Transformer} options.transformers - Map of slug to transformer function
+ * @returns {Promise<Array>} Promise that resolves when all uploads complete
  */
 export default async function transformAndUpload(imageObject, options) {
   const { readableStream, ContentType, Metadata, Key } = imageObject;
-  const { client, bucket } = options;
+  const { client, bucket, transformers } = options;
   const logger = getLogger("transformAndUpload");
 
   logger.trace({ imageObject, options }, "transformAndUpload:params");
 
-  const transformer = sharp().jpeg({ mozjpeg: true });
-  const passThroughStream = new PassThrough();
+  const lastDot = Key.lastIndexOf(".");
+  const filename = lastDot === -1 ? Key : Key.slice(0, lastDot);
+  const extension = lastDot === -1 ? "" : Key.slice(lastDot + 1);
 
-  readableStream.pipe(transformer).pipe(passThroughStream);
+  // Tee stream allows multiple Sharp pipelines to share the same input stream
+  const teeStream = new PassThrough();
+  const uploadPromises = [];
 
-  readableStream.on("error", handleStreamError(passThroughStream));
-  transformer.on("error", handleStreamError(passThroughStream));
-
-  const [filename, extension] = Key.split(".");
-  const minifiedKey = `${filename}-min.${extension}`;
-
-  logger.info({ minifiedKey }, "transforming and uploading image");
-
-  const upload = new Upload({
-    client,
-    params: {
-      Bucket: bucket,
-      Key: minifiedKey,
-      Body: passThroughStream,
-      ContentType,
-      Metadata,
-      ACL: "public-read",
-      ChecksumAlgorithm: "SHA256",
+  logger.info(
+    {
+      imageKey: Key,
+      transformerCount: Object.keys(transformers).length,
+      transformers: Object.keys(transformers)
     },
-    queueSize: 4,
-    partSize: 1024 * 1024 * 5, // 5 MB minimum for multipart parts
+    "starting parallel transformations"
+  );
+
+  // Create a separate pipeline for each transformer
+  for (const [slug, transformer] of Object.entries(transformers)) {
+    const fileKey = extension
+      ? `${filename}${slug}.${extension}`
+      : `${filename}${slug}`;
+
+    // Create a Sharp instance and configure it with the transformer
+    const sharpPipeline = sharp();
+    const configuredPipeline = transformer(sharpPipeline);
+
+    // Create output stream for this transformation
+    const outputStream = new PassThrough();
+
+    // Handle errors on the output stream
+    outputStream.on("error", (err) => {
+      logger.error({ err, fileKey }, "output stream error");
+    });
+
+    // Forward Sharp errors to the matching output stream so the Upload rejects
+    // and sibling pipelines aren't left hanging on the tee.
+    configuredPipeline.on("error", (err) => {
+      logger.error({ err, fileKey }, "transform pipeline error");
+      outputStream.destroy(err);
+    });
+
+    // Pipe: teeStream → Sharp (configured) → outputStream → S3 Upload
+    teeStream.pipe(configuredPipeline);
+    configuredPipeline.pipe(outputStream);
+
+    // Create S3 upload from the output stream
+    const upload = new Upload({
+      client,
+      params: {
+        Bucket: bucket,
+        Key: fileKey,
+        Body: outputStream,
+        ContentType,
+        Metadata,
+        ACL: "public-read",
+        ChecksumAlgorithm: "SHA256",
+      },
+      queueSize: 4,
+      partSize: 1024 * 1024 * 5, // 5 MB minimum for multipart parts
+    });
+
+    upload.on("httpUploadProgress", (progress) => {
+      logger.debug({ progress, fileKey }, "upload progress");
+    });
+
+    uploadPromises.push(upload.done());
+  }
+
+  // Start streaming: readableStream → teeStream → (all Sharp pipelines in parallel)
+  readableStream.pipe(teeStream);
+
+  // Handle errors on the input stream
+  readableStream.on("error", (err) => {
+    logger.error({ err, Key }, "input stream error");
+    teeStream.destroy(err);
   });
 
-  upload.on("httpUploadProgress", (progress) => {
-    logger.info({ progress }, "upload progress");
-  });
-
-  return upload.done();
+  // Wait for all uploads to complete
+  logger.debug({ uploadCount: uploadPromises.length }, "waiting for uploads to complete");
+  return Promise.all(uploadPromises);
 }

--- a/utils/transformAndUpload.test.js
+++ b/utils/transformAndUpload.test.js
@@ -1,0 +1,479 @@
+import test, { mock } from "node:test";
+import assert from "node:assert";
+import EventEmitter from "node:events";
+
+import sharp from "sharp";
+import { createMockImport } from "mock-import";
+
+function makeSharpJpegStream() {
+  return sharp({
+    create: {
+      width: 64,
+      height: 64,
+      channels: 4,
+      background: { r: 10, g: 20, b: 30, alpha: 1 },
+    },
+  }).jpeg();
+}
+
+class MockUpload extends EventEmitter {
+  constructor(options) {
+    super();
+
+    const { client, params, queueSize, partSize } = options;
+    const { Bucket, Key, Body, ContentType, Metadata, ACL, ChecksumAlgorithm } =
+      params;
+
+    this.bucket = Bucket;
+    this.key = Key;
+    this.stream = Body;
+    this.contentType = ContentType;
+    this.metadata = Metadata;
+  }
+
+  done() {
+    return new Promise((resolve, reject) => {
+      this.stream.on("data", (chunk) => {
+        // Stream is flowing - we're not buffering in memory
+      });
+
+      this.stream.on("end", () => {
+        resolve({
+          Bucket: this.bucket,
+          Key: this.key,
+        });
+      });
+
+      this.stream.on("error", (err) => {
+        reject(err);
+      });
+    });
+  }
+}
+
+const { mockImport, reImport, stopAll } = createMockImport(import.meta.url);
+
+test("transformAndUpload", async (t) => {
+  await t.test("export", async () => {
+    const transformAndUpload = await import("./transformAndUpload.js");
+    assert.ok(transformAndUpload.default, "should have a default export");
+    assert.equal(typeof transformAndUpload.default, "function");
+  });
+
+  // await t.test("success", async (t) => {
+  //   mockImport("@aws-sdk/lib-storage", {
+  //     Upload: MockUpload,
+  //   });
+  //
+  //   const mockImageObject = {
+  //     readableStream: sharp({
+  //       create: {
+  //         width: 300,
+  //         height: 200,
+  //         channels: 4,
+  //         background: { r: 255, g: 0, b: 0, alpha: 0.5 },
+  //       },
+  //     }).jpeg(),
+  //     ContentType: {},
+  //     Metadata: {},
+  //     Key: "mock-file.jpg",
+  //   };
+  //
+  //   const mockOptions = {
+  //     client: null,
+  //     bucket: "mockBucket",
+  //     transformers: {
+  //       "-min": (sharp) => {
+  //         return sharp.clone();
+  //       },
+  //     },
+  //   };
+  //
+  //   const transformAndUpload = await reImport("./transformAndUpload.js");
+  //
+  //   console.log("HELLO:", transformAndUpload);
+  //
+  //   await transformAndUpload.default(mockImageObject, mockOptions);
+  //
+  //   stopAll();
+  // });
+
+  await t.test("parallel execution of multiple transformers", async (t) => {
+    // Track upload instances to verify stream usage
+    const uploadInstances = [];
+
+    class TrackingMockUpload extends MockUpload {
+      constructor(options) {
+        super(options);
+        uploadInstances.push(this);
+      }
+    }
+
+    mockImport("@aws-sdk/lib-storage", {
+      Upload: TrackingMockUpload,
+    });
+
+    // Track which transformers were called and verify they return Sharp instances
+    const transformerCalls = [];
+
+    const mockImageObject = {
+      readableStream: sharp({
+        create: {
+          width: 300,
+          height: 200,
+          channels: 4,
+          background: { r: 255, g: 0, b: 0, alpha: 0.5 },
+        },
+      }).jpeg(),
+      ContentType: "image/jpeg",
+      Metadata: { original: "true" },
+      Key: "test-image.jpg",
+    };
+
+    const mockOptions = {
+      client: null,
+      bucket: "test-bucket",
+      transformers: {
+        "-min": (sharpInstance) => {
+          transformerCalls.push({
+            slug: "-min",
+            receivedSharp: !!sharpInstance,
+          });
+          // Configure and return the sharp instance for minification
+          const configured = sharpInstance.jpeg({ mozjpeg: true });
+          assert.ok(
+            configured.constructor.name === "Sharp",
+            "transformer should return a Sharp instance",
+          );
+          return configured;
+        },
+        "-sm": (sharpInstance) => {
+          transformerCalls.push({
+            slug: "-sm",
+            receivedSharp: !!sharpInstance,
+          });
+          // Configure and return the sharp instance for small size
+          const configured = sharpInstance.resize(500).jpeg({ quality: 80 });
+          assert.ok(
+            configured.constructor.name === "Sharp",
+            "transformer should return a Sharp instance",
+          );
+          return configured;
+        },
+        "-md": (sharpInstance) => {
+          transformerCalls.push({
+            slug: "-md",
+            receivedSharp: !!sharpInstance,
+          });
+          // Configure and return the sharp instance for medium size
+          const configured = sharpInstance.resize(1000).jpeg({ quality: 85 });
+          assert.ok(
+            configured.constructor.name === "Sharp",
+            "transformer should return a Sharp instance",
+          );
+          return configured;
+        },
+        "-lg": (sharpInstance) => {
+          transformerCalls.push({
+            slug: "-lg",
+            receivedSharp: !!sharpInstance,
+          });
+          // Configure and return the sharp instance for large size
+          const configured = sharpInstance.resize(2000).jpeg({ quality: 90 });
+          assert.ok(
+            configured.constructor.name === "Sharp",
+            "transformer should return a Sharp instance",
+          );
+          return configured;
+        },
+      },
+    };
+
+    const transformAndUpload = await reImport("./transformAndUpload.js");
+
+    // Execute the function - should process all transformers in parallel
+    const results = await transformAndUpload.default(
+      mockImageObject,
+      mockOptions,
+    );
+
+    // Verify all transformers were called
+    assert.equal(transformerCalls.length, 4, "should call all 4 transformers");
+    assert.ok(
+      transformerCalls.every((call) => call.receivedSharp),
+      "each transformer should receive a Sharp instance",
+    );
+
+    // Verify results array contains all uploads
+    assert.ok(Array.isArray(results), "should return an array of results");
+    assert.equal(results.length, 4, "should return 4 upload results");
+
+    // Verify correct file keys were created
+    const uploadedKeys = results.map((r) => r.Key).sort();
+    const expectedKeys = [
+      "test-image-min.jpg",
+      "test-image-sm.jpg",
+      "test-image-md.jpg",
+      "test-image-lg.jpg",
+    ].sort();
+
+    assert.deepEqual(
+      uploadedKeys,
+      expectedKeys,
+      "should create correct file keys for each transformation",
+    );
+
+    // Verify all uploads used the same bucket
+    assert.ok(
+      results.every((r) => r.Bucket === "test-bucket"),
+      "all uploads should use the same bucket",
+    );
+
+    // Verify that streams (not buffers) were used for uploads
+    assert.equal(uploadInstances.length, 4, "should create 4 upload instances");
+    assert.ok(
+      uploadInstances.every((upload) => upload.stream && upload.stream.pipe),
+      "each upload should use a stream (has pipe method)",
+    );
+
+    stopAll();
+  });
+
+  await t.test("propagates ContentType and Metadata to every Upload", async () => {
+    const uploadInstances = [];
+
+    class TrackingMockUpload extends MockUpload {
+      constructor(options) {
+        super(options);
+        uploadInstances.push(this);
+      }
+    }
+
+    mockImport("@aws-sdk/lib-storage", { Upload: TrackingMockUpload });
+
+    const mockImageObject = {
+      readableStream: makeSharpJpegStream(),
+      ContentType: "image/jpeg",
+      Metadata: { original: "true", source: "unit-test" },
+      Key: "photo.jpg",
+    };
+
+    const mockOptions = {
+      client: null,
+      bucket: "test-bucket",
+      transformers: {
+        "-min": (s) => s.jpeg({ mozjpeg: true }),
+        "-sm": (s) => s.resize(500).jpeg({ quality: 80 }),
+      },
+    };
+
+    const transformAndUpload = await reImport("./transformAndUpload.js");
+    await transformAndUpload.default(mockImageObject, mockOptions);
+
+    assert.equal(uploadInstances.length, 2);
+    assert.ok(
+      uploadInstances.every((u) => u.contentType === "image/jpeg"),
+      "every Upload should receive the source ContentType",
+    );
+    assert.ok(
+      uploadInstances.every(
+        (u) =>
+          u.metadata &&
+          u.metadata.original === "true" &&
+          u.metadata.source === "unit-test",
+      ),
+      "every Upload should receive the source Metadata",
+    );
+
+    stopAll();
+  });
+
+  await t.test("pipes source stream only once (fetch-once invariant)", async () => {
+    mockImport("@aws-sdk/lib-storage", { Upload: MockUpload });
+
+    const source = makeSharpJpegStream();
+    let pipeCount = 0;
+    const originalPipe = source.pipe.bind(source);
+    source.pipe = (...args) => {
+      pipeCount += 1;
+      return originalPipe(...args);
+    };
+
+    const mockImageObject = {
+      readableStream: source,
+      ContentType: "image/jpeg",
+      Metadata: {},
+      Key: "photo.jpg",
+    };
+
+    const mockOptions = {
+      client: null,
+      bucket: "test-bucket",
+      transformers: {
+        "-min": (s) => s.jpeg({ mozjpeg: true }),
+        "-sm": (s) => s.resize(500).jpeg({ quality: 80 }),
+        "-md": (s) => s.resize(1000).jpeg({ quality: 85 }),
+        "-lg": (s) => s.resize(2000).jpeg({ quality: 90 }),
+      },
+    };
+
+    const transformAndUpload = await reImport("./transformAndUpload.js");
+    await transformAndUpload.default(mockImageObject, mockOptions);
+
+    assert.equal(
+      pipeCount,
+      1,
+      "source stream should be piped exactly once regardless of transformer count",
+    );
+
+    stopAll();
+  });
+
+  await t.test("splits Key on the last dot (multi-dot keys)", async () => {
+    const uploadInstances = [];
+    class TrackingMockUpload extends MockUpload {
+      constructor(options) {
+        super(options);
+        uploadInstances.push(this);
+      }
+    }
+    mockImport("@aws-sdk/lib-storage", { Upload: TrackingMockUpload });
+
+    const mockImageObject = {
+      readableStream: makeSharpJpegStream(),
+      ContentType: "image/jpeg",
+      Metadata: {},
+      Key: "folder.v2/photo.original.jpg",
+    };
+
+    const mockOptions = {
+      client: null,
+      bucket: "test-bucket",
+      transformers: { "-min": (s) => s.jpeg({ mozjpeg: true }) },
+    };
+
+    const transformAndUpload = await reImport("./transformAndUpload.js");
+    await transformAndUpload.default(mockImageObject, mockOptions);
+
+    assert.equal(uploadInstances.length, 1);
+    assert.equal(
+      uploadInstances[0].key,
+      "folder.v2/photo.original-min.jpg",
+      "should split on the last dot, preserving earlier dots",
+    );
+
+    stopAll();
+  });
+
+  await t.test("handles Keys with no extension", async () => {
+    const uploadInstances = [];
+    class TrackingMockUpload extends MockUpload {
+      constructor(options) {
+        super(options);
+        uploadInstances.push(this);
+      }
+    }
+    mockImport("@aws-sdk/lib-storage", { Upload: TrackingMockUpload });
+
+    const mockImageObject = {
+      readableStream: makeSharpJpegStream(),
+      ContentType: "image/jpeg",
+      Metadata: {},
+      Key: "photo",
+    };
+
+    const mockOptions = {
+      client: null,
+      bucket: "test-bucket",
+      transformers: { "-min": (s) => s.jpeg({ mozjpeg: true }) },
+    };
+
+    const transformAndUpload = await reImport("./transformAndUpload.js");
+    await transformAndUpload.default(mockImageObject, mockOptions);
+
+    assert.equal(uploadInstances.length, 1);
+    assert.equal(
+      uploadInstances[0].key,
+      "photo-min",
+      "no trailing dot should be appended when Key has no extension",
+    );
+
+    stopAll();
+  });
+
+  await t.test("rejects when a transformer pipeline errors", async () => {
+    mockImport("@aws-sdk/lib-storage", { Upload: MockUpload });
+
+    const source = makeSharpJpegStream();
+    // Swallow late errors from the Sharp source after pipelines are torn down,
+    // so they don't leak into the next test as unhandled events.
+    source.on("error", () => {});
+
+    const mockImageObject = {
+      readableStream: source,
+      ContentType: "image/jpeg",
+      Metadata: {},
+      Key: "photo.jpg",
+    };
+
+    const mockOptions = {
+      client: null,
+      bucket: "test-bucket",
+      transformers: {
+        "-ok": (s) => s.jpeg(),
+        "-boom": (s) => {
+          const configured = s.jpeg();
+          configured.on("error", () => {});
+          queueMicrotask(() => configured.emit("error", new Error("boom")));
+          return configured;
+        },
+      },
+    };
+
+    const transformAndUpload = await reImport("./transformAndUpload.js");
+
+    await assert.rejects(
+      transformAndUpload.default(mockImageObject, mockOptions),
+      /boom/,
+      "should reject with the transformer error",
+    );
+
+    stopAll();
+  });
+
+  await t.test("is a no-op when transformers is empty", async () => {
+    const uploadInstances = [];
+    class TrackingMockUpload extends MockUpload {
+      constructor(options) {
+        super(options);
+        uploadInstances.push(this);
+      }
+    }
+    mockImport("@aws-sdk/lib-storage", { Upload: TrackingMockUpload });
+
+    const mockImageObject = {
+      readableStream: makeSharpJpegStream(),
+      ContentType: "image/jpeg",
+      Metadata: {},
+      Key: "photo.jpg",
+    };
+
+    const mockOptions = {
+      client: null,
+      bucket: "test-bucket",
+      transformers: {},
+    };
+
+    const transformAndUpload = await reImport("./transformAndUpload.js");
+    const results = await transformAndUpload.default(mockImageObject, mockOptions);
+
+    assert.deepEqual(results, [], "should resolve to an empty array");
+    assert.equal(
+      uploadInstances.length,
+      0,
+      "should not construct any Upload instances",
+    );
+
+    stopAll();
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the per-image, per-variant fetch loop with a fetch-once / fan-out pipeline: each source image is streamed from S3 a single time through a `PassThrough` tee into N Sharp pipelines, and every transformed stream is uploaded back to S3 in parallel via `@aws-sdk/lib-storage`.
- Introduces a `tasks/` directory of slug-keyed transformers (`-min`, `-sm`, `-md`, `-lg`) plus a `groupDifferences` util so the main loop knows exactly which variants each image is missing.
- Hardens `transformAndUpload`: forwards Sharp pipeline errors to the matching output stream so the corresponding upload rejects without hanging siblings, and splits `Key` on the last dot so paths and multi-dot names round-trip correctly.

## Test plan

- [x] `npm test` — 55/55 passing (unit, no network)
- [x] New tests cover: fan-out / fetch-once invariant, `ContentType`/`Metadata` propagation, multi-dot and extensionless keys, transformer error rejection, empty-transformers no-op
- [ ] Manual end-to-end run against a staging bucket: invoke `handler` once, confirm exactly one `GetObject` and four uploads per source image with keys `name-min.jpg`, `name-sm.jpg`, `name-md.jpg`, `name-lg.jpg`
- [ ] Memory check on a >50 MB source image: RSS stays well below the image size

## Follow-ups

- `transformAndUpload` has no `error` listener on the internal `teeStream`; a source-stream error path can therefore leak as `uncaughtException`. A targeted test for that path was deferred (documented in the planning notes) and should be paired with a switch to `stream.pipeline()` per branch so error/cleanup propagation is automatic.